### PR TITLE
“back-end” -> “backend”

### DIFF
--- a/Chapters/CaseStudyOne/CaseStudyOne.md
+++ b/Chapters/CaseStudyOne/CaseStudyOne.md
@@ -20,7 +20,7 @@ https://github.com/SquareBracketAssociates/CodeOfSpec20Book
 ### Application
 
 Spec20 introduces the concept of an application. An _application_ is a small object responsible for keeping the state of your application. 
-It manages, for example, the multiple windows that can compose your application, and its back-end (Morphic or Gtk), and can hold properties shared by the application.
+It manages, for example, the multiple windows that can compose your application, and its backend (Morphic or Gtk), and can hold properties shared by the application.
 
 We start to define an application as follows: 
 
@@ -29,7 +29,7 @@ SpApplication << #ImdbApp
     package: 'Spec2-TutorialOne'
 ```
 
-In this example, we will show how we define which back-end to use and this will allow us to switch between Morphic and GTK.
+In this example, we will show how we define which backend to use and this will allow us to switch between Morphic and GTK.
 
 ### A basic film model
 

--- a/Chapters/InANutshell/InANutshell.md
+++ b/Chapters/InANutshell/InANutshell.md
@@ -30,8 +30,8 @@ Figure *@coreextended@* presents the general architecture of Spec. Basically, Sp
 
 A presenter represents the UI element logic and it is also the connection with the domain.  The Application is also a place to be in contact with domain objects but generally, it handles application-specific resources (icons, windows...).
 
-Based on presenters and layout, Spec builds the actual UI. To do so it internally uses adapters that are specific to each widget and per back-end. 
-This way presenters are totally agnostic about back-ends and are reusable across them. 
+Based on presenters and layout, Spec builds the actual UI. To do so it internally uses adapters that are specific to each widget and per backend. 
+This way presenters are totally agnostic about backends and are reusable across them. 
 
 
 ![Architecture of Spec.](figures/coreExtended.pdf label=coreextended&width=80) 
@@ -131,7 +131,7 @@ ImdbMorphicConfiguration >> configure: anApplication
 ```
 Note that we could use a style described in a string as shown in the Style chapter (Chapter *@style@*).
 
-Finally, in the corresponding application class, we declare that the Morphic back-end should use our configuration 
+Finally, in the corresponding application class, we declare that the Morphic backend should use our configuration 
 using the message `useBackend:with:`.
 
 ```language=Smalltalk
@@ -222,7 +222,7 @@ Chapter *@chastyle@* presents styles in detail.
  
 A style is a property container to “style” components, and defines (in a certain degree) its behavior within the different layouts implemented.
  
-Here is an example of a style sheet for the Morphic back-end:
+Here is an example of a style sheet for the Morphic backend:
  
 ```
 '.application [       

--- a/Chapters/Intro/Intro.md
+++ b/Chapters/Intro/Intro.md
@@ -4,9 +4,9 @@
 status: ready for review
 
 Spec is a framework in Pharo for describing user interfaces. It allows for the construction of a wide variety of UIs; from small windows with a few buttons up to complex tools like a debugger. Indeed, multiple tools in Pharo are written in Spec, e.g., Iceberg the git manager, Change Sorter, Critics Browser, and the Pharo debugger.
-An important architectural decision is that Spec supports multiple back-ends \(at the time of writing this book, GTK and Morphic are available\).
+An important architectural decision is that Spec supports multiple backends \(at the time of writing this book, GTK and Morphic are available\).
 
-![Spec supports multiple back-ends Morphic and GTK3.0.: Here we see GTK.](figures/GTK.png width=100)
+![Spec supports multiple backends Morphic and GTK3.0.: Here we see GTK.](figures/GTK.png width=100)
 
 
 ### Reuse of logic
@@ -33,8 +33,8 @@ Spec 2.0 represents a large iteration over Spec 1. Many enhancements have been i
 
 
 Pharo's objective is to use Spec to build all its own GUIs. This ensures strong support of Spec over time and improves the standardization of Pharo's interfaces as well as their portability to new graphical systems.
-Using Spec2 provides back-end independence and logic reuse.
-This means that a UI written in Spec will be rendered on back-ends other than GTK and Morphic. As new back-ends become available, all applications written in Spec will be able to use them.
+Using Spec2 provides backend independence and logic reuse.
+This means that a UI written in Spec will be rendered on backends other than GTK and Morphic. As new backends become available, all applications written in Spec will be able to use them.
 
 While this book uses previous Spec documentation as a foundation, the text has been almost completely rewritten with an aim toward higher quality. We hope that it will be of use to developers who write UIs in Pharo.
 

--- a/Chapters/TestingInSpec/TestingInSpec.md
+++ b/Chapters/TestingInSpec/TestingInSpec.md
@@ -19,12 +19,12 @@ Tests are key to ensuring that everything works correctly. In addition, they fre
 
 
 Spec is based on an architecture with three different layers as shown in Figure *@fig:Architecture@*: 
-- **Presenters:** Presenters define the interaction logic and manipulate domain objects. They access back-end widgets but via an API that is specified by Adapters.
-- **Adapters:** Adapters are objects exposing low-level back-end widgets. They are a bridge between presenters and low-level widgets.
-- **Back-end widgets**. Back-end widgets are plain widgets that can be used without Spec.
+- **Presenters:** Presenters define the interaction logic and manipulate domain objects. They access backend widgets but via an API that is specified by Adapters.
+- **Adapters:** Adapters are objects exposing low-level backend widgets. They are a bridge between presenters and low-level widgets.
+- **Backend widgets**. Backend widgets are plain widgets that can be used without Spec.
 
 
-![Spec Architecture: three layers Presenters - Adapters - Back-ends.](figures/ArchitectureSpec2.pdf width=95&label=fig:Architecture)
+![Spec Architecture: three layers Presenters - Adapters - Backends.](figures/ArchitectureSpec2.pdf width=95&label=fig:Architecture)
 
 #### Three roles and concerns
 
@@ -32,7 +32,7 @@ To help you understand the different possibilities of testing that you can engag
 
 - **Spec Users.**Spec users are developers that build a new application. They define the logic of the application by assembling together presenters and domain objects. We believe that this is in the role that you will play most of the time.
 - **Spec Developers.** Spec developers are more concerned with the development of new Spec presenter and their link with the adapter.
-- **Widget Developers.** Widget developers are concerned about the logic and working of a given widget for a given back-end.
+- **Widget Developers.** Widget developers are concerned about the logic and working of a given widget for a given backend.
 
 
 % +UI elements under test.>file://figures/UI.png|width=75|label=fig:UI+
@@ -41,7 +41,7 @@ To help you understand the different possibilities of testing that you can engag
 
 We will focus on the first role. For the reader interested in the second role, the class `SpAbstractBackendForTest` is a good starting place.
 
-As a Spec user, you should consider that the back-ends are working and your responsibility is to test the logic of the user interface components.
+As a Spec user, you should consider that the backends are working and your responsibility is to test the logic of the user interface components.
 We should make sure that when the model changes, the user interface components reflect the changes.
 Inversely when the user interface components change, we should ensure that the model is updated.
 But let us check an example.


### PR DESCRIPTION
As discussed by e-mail, all references to `back-end` have been replaced by `backend`. I also searched for `back end`, but did not find any.