### PR TITLE
Improvements to chapter 11 (Layouts)

### DIFF
--- a/Chapters/LayoutContruction/Layout.md
+++ b/Chapters/LayoutContruction/Layout.md
@@ -5,43 +5,41 @@ status: to be finished
 status: spellchecker
 
 In Spec2 layouts are represented by instances of layout classes. Such layout classes encode different positioning of elements such as box, paned, or grid layouts.
-This chapter presents the existing layouts, their definition, and how layouts can be reused when 
-a presenter reuses other presenters.
+This chapter presents the available layouts, their definition, and how layouts can be reused when a presenter reuses other presenters.
 
 ### Basic principle reminder
 
-Spec expects to get layouts objects, instances of the layout classes, associated with a presenter. Each presenter should describe the positioning of its sub-presenters. 
+Spec expects that layouts objects, instances of the layout classes, are associated with a presenter. Each presenter should describe the positioning of its sub-presenters.
 
 Contrary to Spec1.0 where layouts were only defined at the class level, in Spec2.0
-to define the layout of a presenter you can: 
+to define the layout of a presenter you can:
 - Define the `defaultLayout` method on the instance side,
 - Or use the message `layout:` in your `initializePresenters` method to set an instance of layout in the current presenter.
 
-Both layout methods should return a layout, for example, instance of `SpBoxLayout` or `SpPanedLayout`. These two methods are the preferred way to define layouts.
+`defaultLayout` returns a layout and `layout:` sets a layout, for example, an instance of `SpBoxLayout` or `SpPanedLayout`. These two methods are the preferred way to define layouts.
 
-Note the possibility of defining a class-side accessor e.g. `defaultLayout` will remain for those who prefer it.
+Note that the possibility of defining a class-side accessor e.g. `defaultLayout` will remain for those who prefer it.
 
-This new design reflects the dynamic nature of layouts in Spec2, and the fact that you can compose them using directly presenter instances, not forcing you to declare upfront sub-presenters in instance variables and then use their names as it was done in Spec1.0.
+This new design reflects the dynamic nature of layouts in Spec2, and the fact that you can compose them using presenter instances directly, not forcing you to declare sub-presenters in instance variables upfront and then use their names as it was done in Spec1.0.
 It is, however, possible that there are cases where you want a layout "template"... so you still can do it.
 
 
 ### A running example
 
-To be able to play with the layouts defined in this chapter, 
-we define a simple presenter named `SpTwoButtons`.
- 
-``` 
-SpPresenter << #SpTwoButtons 
-    slots: { #button1 . #button2 }; 
+To be able to play with the layouts defined in this chapter, we define a simple presenter named `TwoButtons`.
+
+```
+SpPresenter << #TwoButtons
+    slots: { #button1 . #button2 };
     package: 'CodeOfSpec20BookThreePillar'
 ```
 
-We define a simple `initializePresenters` method as follows: 
+We define a simple `initializePresenters` method as follows:
 
 ```
-SpTwoButtons >> initializePresenters 
-    button1 := self newButton. 
-    button2 := self newButton. 
+TwoButtons >> initializePresenters
+    button1 := self newButton.
+    button2 := self newButton.
 
     button1 label: '1'.
     button2 label: '2'.
@@ -51,23 +49,22 @@ SpTwoButtons >> initializePresenters
 
 ### BoxLayout (SpBoxLayout and SpBoxConstraints)
 
-The class `SpBoxLayout` displays presenters in an ordered sequence of boxes. 
-A box can be horizontal or vertical and presenters are ordered top to down or left to right following the direction decided. A box layout can be composed of other layouts.
+The class `SpBoxLayout` displays presenters in an ordered sequence of boxes. A box can be horizontal or vertical and presenters are ordered top to bottom or left to right following the direction decided. A box layout can be composed of other layouts.
 
 
-![Two buttons placed horizontally from left to right.](figures/TwoButtonsLeftToRight.png width=50&label=TwoButtonsLeftToRight) 
+![Two buttons placed horizontally from left to right.](figures/TwoButtonsLeftToRight.png width=50&label=TwoButtonsLeftToRight)
 
 Let us define a first simple layout whose result is displayed in  Fig. *@TwoButtonsLeftToRight@* as follows.
 
 ```
-SpTwoButtons >> defaultLayout
+TwoButtons >> defaultLayout
      ^ SpBoxLayout newLeftToRight
-        add: button1; 
-        add: button2; 
+        add: button1;
+        add: button2;
         yourself
 ```
 
-What we see is that by default a presenter expands its size to fit the space of its container. 
+What we see is that by default a presenter expands its size to fit the space of its container.
 
 An element in a vertical box will use all available horizontal space, and fill
 vertical space according to the rules. This is inversed in a horizontal box.
@@ -75,14 +72,14 @@ vertical space according to the rules. This is inversed in a horizontal box.
 We can refine this layout to indicate that the sub-presenters should not expand to their container using the message `add:expand:`. The result is shown in Figure *@TwoButtonsLeftToRightExpanded@*.
 
 ```
-SpTwoButtons >> defaultLayout
+TwoButtons >> defaultLayout
     ^ SpBoxLayout newLeftToRight
-        add: #button1 expand: false ; 
-        add: #button2 expand: false ;
+        add: #button1 expand: false;
+        add: #button2 expand: false;
         yourself
 ```
 
-![Two buttons placed horizontally from left to right but not expanded.](figures/TwoButtonsLeftToRightNotExpanded.png width=50&label=TwoButtonsLeftToRightExpanded) 
+![Two buttons placed horizontally from left to right but not expanded.](figures/TwoButtonsLeftToRightNotExpanded.png width=50&label=TwoButtonsLeftToRightExpanded)
 
 The full message to add presenters is: `add:expand:fill:padding:`
 - `expand:` argument - when true, the new child is to be given extra space allocated to the box. The extra space is divided evenly between all children that use this option.
@@ -90,22 +87,20 @@ The full message to add presenters is: `add:expand:fill:padding:`
 - `padding:` argument  - extra space in pixels to put between this child and its neighbors, over and above the global amount specified by “spacing” property. If a child is a widget at one of the reference ends of the box, then padding pixels are also put between the child and the reference edge of the box.
 
 
-To illustrate a bit this API, we add another button to the presenter and change the `defaultLayout` method as follows. 
-The result is shown in Fig *@ThreeButtons@*. 
-We want to stress however that it is better not to use a fixed width or padding.
+To illustrate this API a bit, we add another button to the presenter and change the `defaultLayout` method as follows. The result is shown in Fig *@ThreeButtons@*. We want to stress however that it is better not to use a fixed width or padding.
 
 ```smalltalk
-SpTwoButtons >> defaultLayout 
+TwoButtons >> defaultLayout
     ^ SpBoxLayout newTopToBottom
         spacing: 15;
         add: button1 expand: false fill: true padding: 5;
         add: button2 withConstraints: [ :constraints | constraints width: 30; padding: 5];
         addLast: button3 expand: false fill: true padding: 5;
-    yourself
+        yourself
 ```
 
 
-![Three buttons placed from top to bottom playing with padding and fill options.](figures/ThreeButtons.png width=50&label=ThreeButtons) 
+![Three buttons placed from top to bottom playing with padding and fill options.](figures/ThreeButtons.png width=50&label=ThreeButtons)
 
 
 
@@ -116,20 +111,22 @@ Before presenting some of the other layouts, we show an important aspect of Spec
 Consider our artificial example of a two-button UI. Let us define two layouts as follows:
 We define two class methods returning different layouts. Note that we could define such methods on the instance side too and we define them on the class side to be able to get such layouts without an instance of the class.
 
-``` 
-SpTwoButtons class >> buttonRow 
-    ^ SpBoxLayout newLeftToRight 
-        add: #button1; add: #button2; 
-        yourself 
-``` 
- 
-``` 
-SpTwoButtons class >> buttonCol 
-    ^ SpBoxLayout newTopToBottom 
-        add: #button1; add: #button2; 
-        yourself 
-``` 
- 
+```
+TwoButtons class >> buttonRow
+    ^ SpBoxLayout newLeftToRight
+        add: #button1;
+        add: #button2;
+        yourself
+```
+
+```
+TwoButtons class >> buttonColumn
+    ^ SpBoxLayout newTopToBottom
+        add: #button1;
+        add: #button2;
+        yourself
+```
+
 Note that when we define the layout at the class level, we use a symbol whose name is the corresponding instance variable. Hence we use `#button2` to refer to the presenter stored in the instance variable `button2`. This mapping can be customized at the level of the presenter but we do not present this because we never got the need for it. 
 
 
@@ -137,18 +134,16 @@ Note that when we define the layout at the class level, we use a symbol whose na
 
 Spec message `openWithLayout:` lets you specify the layout you want to use to open the presenter.
 Here are some examples:
-- `SpTwoButtons new openWithLayout: SpTwoButtons buttonRow` places the buttons in a row. 
-- `SpTwoButtons new openWithLayout:  SpTwoButtons buttonCol` places them in a column. 
+- `TwoButtons new openWithLayout: TwoButtons buttonRow` places the buttons in a row.
+- `TwoButtons new openWithLayout: TwoButtons buttonColumn` places them in a column.
 
 
 
-We define a `defaultLayout` method just invoking one of the previously defined methods.
-``` 
-SpTwoButtons >> defaultLayout 
-    ^ self class buttonRow 
+We define a `defaultLayout` method just invoking one of the previously defined methods so that the presenter can be opened without defining a given layout.
 ```
-
-We define also a `defaultLayout` method so that the presenter can be opened without defining a given layout. 
+TwoButtons >> defaultLayout
+    ^ self class buttonRow
+```
 
 
 ### Better design
@@ -156,129 +151,121 @@ We define also a `defaultLayout` method so that the presenter can be opened with
 Now we can do better and define two instance level methods to encapsulate the layout configuration. 
 
 ```
-SpTwoButtons >> beCol
-    self layout: self class buttonCol
+TwoButtons >> beColumn
+    self layout: self class buttonColumn
 ```
 
 ```
-SpTwoButtons >> beRow
+TwoButtons >> beRow
     self layout: self class buttonRow
 ```
 
 We can then write the following script:
 
 ```
-SpTwoButtons new 
-    beCol;
-    open 
+TwoButtons new
+    beColumn;
+    open
 ```
 
 
-### Specifying a layout when reusing a presenter 
+### Specifying a layout when reusing a presenter
 
-Having multiple layouts for a presenter implies that there is a way to specify the layout to use when a presenter is reused. 
-This is simple we use the method `layout:`.
-Here is an example. 
-We create a new presenter named: `SpButtonAndListH`.
- 
-``` 
-SpPresenter << #SpButtonAndListH 
-    slots: { #buttons . #list }; 
+Having multiple layouts for a presenter implies that there is a way to specify the layout to use when a presenter is reused. This is simple. We use the method `layout:`. Here is an example. We create a new presenter named `ButtonAndListH`.
+
+```
+SpPresenter << #ButtonAndListH
+    slots: { #buttons . #list };
     package: 'CodeOfSpec20BookThreePillar'
 ```
 
 
 ```
-SpButtonAndListH >> initializePresenters 
-    buttons := self instantiate: SpTwoButtons. 
-    list := self newList. 
-    list items: (1 to: 10). 
-``` 
-
-``` 
-SpButtonAndListH >> initializeWindow: aWindowPresenter 
-    aWindowPresenter title: 'SuperWidget' 
+ButtonAndListH >> initializePresenters
+    buttons := self instantiate: TwoButtons.
+    list := self newList.
+    list items: (1 to: 10).
 ```
 
 ```
-SpButtonAndListH >> defaultLayout 
-    ^ SpBoxLayout newLeftToRight 
+ButtonAndListH >> initializeWindow: aWindowPresenter
+    aWindowPresenter title: 'SuperWidget'
+```
+
+```
+ButtonAndListH >> defaultLayout
+    ^ SpBoxLayout newLeftToRight
           add: buttons;
-          add: list; 
-          yourself 
+          add: list;
+          yourself
 ```
 
 
-This `SpButtonAndListH ` class results in a SuperWidget window as shown in Figure *@fig_alternativeButton@*.  
-It reuses the `SpTwoButtons` widget and places all three widgets in a horizontal order because the `SpTwoButtons` widget will use the `buttonRow` layout method. 
- 
-![Screen shot of the UI with buttons placed horizontally](figures/alternativeButton.png width=50&label=fig_alternativeButton) 
- 
-Alternatively, we can create `TBAndListV` class as a subclass of `SpButtonAndListH ` and only change the `defaultLayout` method as below.
-It specifies that the reused `buttons` widget should use the `buttonCol` layout method, and hence results in the window shown in Figure *@fig_SuperWidget@*.
+This `ButtonAndListH` class results in a SuperWidget window as shown in Figure *@fig_alternativeButton@*. It reuses the `TwoButtons` widget and places all three widgets in a horizontal order because the `TwoButtons` widget uses the `buttonRow` layout method.
 
+![Screenshot of the UI with buttons placed horizontally](figures/alternativeButton.png width=50&label=fig_alternativeButton)
 
-![Screen shot of the UI with buttons placed vertically](figures/SuperWidget.png width=50&label=fig_SuperWidget) 
+Alternatively, we can create `TButtonAndListV` class as a subclass of `ButtonAndListH` and only change the `initializePresenters` method as below. It specifies that the reused `buttons` widget should use the `buttonColumn` layout method, and hence results in the window shown in Figure *@fig_SuperWidget@*.
 
-``` 
-SpButtonAndListH << #TButtonAndListV 
+```
+ButtonAndListH << #TButtonAndListV
     package: 'CodeOfSpec20BookThreePillar'
-``` 
- 
+```
+
 ```
 TButtonAndListV >> initializePresenters
     super initializePresenters.
-    buttons beCol
+    buttons beColumn
 ```
 
-##### Alternative to declare subcomponent layout choice.
+![Screenshot of the UI with buttons placed vertically](figures/SuperWidget.png width=50&label=fig_SuperWidget)
 
-The alternative is to define a new method `defaultLayout` and to use the `add:layout:`. 
-We define a different presenter.
+
+##### Alternative to declare subcomponent layout choice
+
+The alternative is to define a new method `defaultLayout` and to use the `add:layout:` message. We define a different presenter.
 
 ```
-SpButtonAndListH << #TButtonAndListV2
+ButtonAndListH << #TButtonAndListV2
     package: 'CodeOfSpec20BookThreePillar'
 ```
 
-We define a new `defaultLayout` method as follows: 
+We define a new `defaultLayout` method as follows:
 
-``` 
-SpButtonAndListV2 >> defaultLayout
+```
+ButtonAndListV2 >> defaultLayout
     ^ SpBoxLayout new
-        add: buttons layout: #buttonCol;
+        add: buttons layout: #buttonColumn;
         add: list;
         yourself
 ```
 
-Note the use of the method `add:layout:` with the selector of the method returning the layout configuration 
-here #buttonCol. This is normal since we cannot access the state of a subcomponent at this moment.
+Note the use of the message `add:layout:` with the selector of the method returning the layout configuration: #buttonColumn. This is normal since we cannot access the state of a subcomponent at this moment.
 
 ##### Dynamically changing a layout
 It is possible to change the layout of a presenter dynamically for example from the inspector as shown in *@figTweak@*.
 
-![Tweaking and playing interactively with layouts from the inspector.](figures/Interactive.png width=100&label=figTweak) 
+![Tweaking and playing interactively with layouts from the inspector.](figures/Interactive.png width=100&label=figTweak)
 
 
 
-### GridLayout 
+### Grid layout
 
-The class `SpGridLayout` arranges sub-presenters in a grid according to its properties (position and
-span), and according to certain layout properties such as:
+The class `SpGridLayout` arranges sub-presenters in a grid according to certain layout properties such as:
 - A position is mandatory (`columnNumber@rowNumber`)
 - A span can be added if desired (`columnExtension@rowExtension`)
 
-The following example 
+The following example opens a window with a grid layout with several widgets, as shown in Figure *@grid@*.
 
 ```
-SpPresenter << #SpGridExample
+SpPresenter << #GridExample
 	slots: {#nameText . #passwordText . #acceptButton . #cancelButton};
 	package: 'CodeOfSpec20BookThreePillar'
 ```
 
 ```
-SpGridExample >> initializePresenters
-    nameText := self newTextInput.   
+GridExample >> initializePresenters
+    nameText := self newTextInput.
     passwordText := self newTextInput.
     acceptButton := self newButton.
     acceptButton label: 'Accept'.
@@ -287,53 +274,50 @@ SpGridExample >> initializePresenters
 ```
 
 
-```smalltalk
-SpGridExample >> defaultLayout
+```
+GridExample >> defaultLayout
     ^ SpGridLayout new
         add: 'Name:' at: 1@1;
-        add: #nameText  at: 2@1;
+        add: #nameText at: 2@1;
         add: 'Password:' at: 1@2;
-        add: #passwordText at: 2@2;  
+        add: #passwordText at: 2@2;
         add: #acceptButton at: 1@3;
         add: #cancelButton at: 2@3 span: 2@3;
         add: 'test label' at: 1@4;
         yourself
 ```
 
-![An ugly example .](figures/grid.png width=90&label=grid) 
+![An ugly example.](figures/grid.png width=90&label=grid)
 
-Here is a list of options: 
+Here is a list of options:
 - `columnHomogeneous`: Whether a column will have the same size.
 - `rowHomogeneous`: Whether a row will have the same size.
-- `colSpacing:`: The column space between cells.
-- `rowSpacing:`: The row space between cells.
+- `colSpacing:`: The horizontal space between cells.
+- `rowSpacing:`: The vertical space between cells.
 
 
 
 ### Paned layout (SpPanedLayout and SpPanedConstraints)
 
-A paned layout is like a Box Layout (it places children in a vertical or horizontal
-fashion), but it will add a splitter in between, that the user can drag to resize the panel.
-In exchange, a paned layout can have just two children. Position indicates
-the original position of the splitter. It can be nil (then it defaults to 50%) or It can
-be a percentage (e.g. 30 percent)
+A paned layout is like a box layout. It places children in a vertical or horizontal fashion, but it will add a splitter in between, that the user can drag to resize the panels. A paned layout can have at most two children. `positionOfSlider:` indicates the original position of the splitter. It can be nil (then it defaults to 50%) or it can be a percentage (e.g. 30 percent)
 
-```smalltalk
-SpPanedLayout newHorizontal position: 80 percent;
+```
+SpPanedLayout newHorizontal
+    positionOfSlider: 80 percent;
     add: acceptButton;
     add: cancelButton;
     yourself.
 ```
 
-        
-        
-### Overlay
+
+
+### Overlay layout
 
 
 ```
 app := SpApplication new.
 app addStyleSheetFromString: '.application [
-        .green [ 
+        .green [
             Draw {
                 #backgroundColor: #16A085
             }
@@ -347,18 +331,18 @@ app addStyleSheetFromString: '.application [
 ]'.
 
 presenter := SpPresenter newApplication: app.
-    
+
 child := presenter newPresenter
-     layout: (SpBoxLayout new
-         hAlignCenter;
-         vAlignCenter;
+    layout: (SpBoxLayout new
+        hAlignCenter;
+        vAlignCenter;
         add: ('I AM THE CHILD' asPresenter
-                  addStyle: 'title';
-                yourself);
+            addStyle: 'title';
             yourself);
-          addStyle: 'green';
-        yourself.
-        
+        yourself);
+    addStyle: 'green';
+    yourself.
+
 overlay := presenter newPresenter
     layout: SpBoxLayout newVertical;
     addStyle: 'redOverlay';
@@ -366,20 +350,15 @@ overlay := presenter newPresenter
 
 presenter layout: (SpOverlayLayout new
      child: child;
-     addOverlay: overlay withConstraints: [ :c | 
+     addOverlay: overlay withConstraints: [ :c |
          c
-             vAlignCenter;
-             hAlignCenter ];
+            vAlignCenter;
+            hAlignCenter ];
      yourself).
-            
-presenter open.
 
+presenter open.
 ```
 
 ### Conclusion
 
-Spec offers several predefined layouts. New ones will probably be added but in compatible way.
-An important closing point is that layouts can be dynamically composed. It means that you will  be able to 
-design applications that can adapt to specific conditions.
-
-
+Spec offers several predefined layouts. New ones will probably be added but in a compatible way. An important closing point is that layouts can be dynamically composed. It means that you are able to design applications that can adapt to specific conditions.


### PR DESCRIPTION
This is the first-pass review of chapter 11 on "Layouts".

In my opinion, this chapter is important so it should be extensive. I think it is not ready for prime time.

In this PR improvements to the text are suggested, and mistakes in the code have been corrected. In particular, I removed the `Sp` prefix from the class names that are examples, as `Sp` is the prefix used for Spec classes and the examples are *not* Spec classes. I also changed abbreviated names to meaningful full names.

This PR is a first pass because iteration is required:
* I think the box layout deserves more love. There is much more to say than what is used in the examples, e.g. alignment and nesting box layouts to produce more complex layouts. I was already planning a blog post about this subject. Maybe I should write that first so that you can see what I mean. Afterward, we can decide whether (parts of) it should be included in the book.
* In the paned layout section the possible values for the position of the slider are incomplete. Floats and fractions are allowed as well. See the comment in `SpPanedLayout>>#positionOfSlider:`.
* An introductory text is missing from the section on the overlay layout.
* A figure is missing from the section on the overlay layout.
* I did not try the example in the overlay layout section, but I think we can provide a better example. E.g. a tag with a number overlayed on a widget to indicate how many things need attention, like "5" on an icon that indicates an inbox. It would be a better example than the current example with "I AM THE CHILD".
* The example in the overlay layout section uses `#asPresenter`, but it has not been introduced yet.
* The constraints classes are mentioned in headers, and `#add:withConstraints:` is used in examples, but they are not explained.
* The reason why "it is better not to use fixed width or padding" is not explained. Moreover, I disagree with the statement. I have a good counter-example. Let's discuss that sometime (not here in this PR). That example will be the main example in te blog post I mentioned above.