### PR TITLE
Improvements to chapter 3 (Most of Spec in one example)

### DIFF
--- a/Chapters/CaseStudyOne/CaseStudyOne.md
+++ b/Chapters/CaseStudyOne/CaseStudyOne.md
@@ -4,10 +4,9 @@
 status: ready for review I got an error with ports so should check with esteban
 status: grammarly passed
 
-In this chapter, we will guide you through the building of a simple but not trivial 
-application to manage films as shown in Figure *@FullApp@*.
+In this chapter, we will guide you through the building of a simple but not trivial application to manage films as shown in Figure *@FullApp@*.
 We will show many aspects of Spec20 that we will revisit in depth in the rest of this book:
-the application, presenters, the separation between domain and model, layout, transmissions to connect widgets,  and styles. 
+the application, presenters, the separation between domain and model, layout, transmissions to connect widgets,  and styles.
 
 ![Film App: reusing the same component to edit and browsing a film.](figures/FullApp.png width=90&label=FullApp)
 
@@ -19,12 +18,11 @@ https://github.com/SquareBracketAssociates/CodeOfSpec20Book
 
 ### Application
 
-Spec20 introduces the concept of an application. An _application_ is a small object responsible for keeping the state of your application. 
-It manages, for example, the multiple windows that can compose your application, and its backend (Morphic or Gtk), and can hold properties shared by the application.
+Spec20 introduces the concept of an application. An _application_ is a small object responsible for keeping the state of your application. It manages, for example, the multiple windows that can compose your application, and its backend (Morphic or Gtk), and can hold properties shared by the application.
 
-We start to define an application as follows: 
+We start to define an application as follows:
 
-```language=Smalltalk
+```
 SpApplication << #ImdbApp
     package: 'Spec2-TutorialOne'
 ```
@@ -35,20 +33,19 @@ In this example, we will show how we define which backend to use and this will a
 
 Since we will manage films we define a `Film` class as follows: It has a name, a year, and a director. We generate the companion accessors.
 
-```language=Smalltalk
+```
 Object << #ImdbFilm
     slots: {#name . #year . #director};
     package: 'Spec-TutorialOne'
 ```
 
 
-We need to have a way to store and query some films. 
-We could use Voyage [https://github.com/pharo-nosql/voyage](https://github.com/pharo-nosql/voyage) since it works without an external Mongo DB. But we want to keep it extremely simple.
+We need to have a way to store and query some films. We could use Voyage [https://github.com/pharo-nosql/voyage](https://github.com/pharo-nosql/voyage) since it works without an external Mongo DB. But we want to keep it extremely simple.
 So let's define a kind of singleton.
 
-We define a _class_ instance variable called `films` (you can use the 'expand' menu item to get the full definition on the class side).
+We define a _class_ instance variable called `films`.
 
-```language=Smalltalk
+```
 Object class << ImdbFilm class
     slots: { #films }
 ```
@@ -56,7 +53,7 @@ Object class << ImdbFilm class
 
 We define a method that lazy initializes the `films` variable to an ordered collection.
 
-```language=Smalltalk
+```
 ImdbFilm class >> films
     ^ films ifNil: [ films := OrderedCollection new ]
 ```
@@ -64,7 +61,7 @@ ImdbFilm class >> films
 
 And to finish we define a way to add a film to the list.
 
-```language=Smalltalk
+```
 ImdbFilm class >> addFilm: aFilm
     films add: aFilm
 ```
@@ -73,56 +70,52 @@ Now we are ready to define a first presenter that manages a list of films.
 
 ### List of films
 
-We define a presenter to manage a list of films by defining a new class named `ImdbFilmListPresenter` which inherits from `SpPresenter`.
-We add an instance variable named `filmList` that will hold an elementary list presenter. 
+We define a presenter to manage a list of films by defining a new class named `ImdbFilmListPresenter` which inherits from `SpPresenter`. We add an instance variable named `filmList` that will hold an elementary list presenter.
 
-Note that a presenter such as `ImdbFilmListPresenter` can have multiple subpresenters. 
+Note that a presenter such as `ImdbFilmListPresenter` can have multiple subpresenters.
 
-```language=Smalltalk
+```
 SpPresenter << #ImdbFilmListPresenter
     slots: { #filmList };
     package: 'Spec-TutorialOne'
 ```
 
 
-We define how the information should be presented by defining a method named `defaultLayout`. 
-Here we define a simple layout: a list of boxes displayed vertically.
-We are declaring that inside this box layout, there is a specific presenter for the list itself and it is named `filmList`.
+We define how the information should be presented by defining a method named `defaultLayout`. Here we define a simple layout: a list of boxes displayed vertically. We are declaring that inside this box layout, there is a specific presenter for the list itself and it is named `filmList`.
 
 #### defaultLayout
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> defaultLayout
     ^ SpBoxLayout newTopToBottom
-        add: filmList; 
+        add: filmList;
         yourself
 ```
 
 When you do not define any other methods to represent layout, `defaultLayout` is the method that is invoked by Spec logic.
 
-A presenter can have subpresenters e.g., `ImdbFilmListPresenter` will contain table presenters and you will see later that 
-1.    a presenter can have multiple layouts and
-2.    that layouts can be defined dynamically.
+A presenter can have subpresenters e.g., `ImdbFilmListPresenter` will contain table presenters and you will see later that
+1. a presenter can have multiple layouts and
+2. that layouts can be defined dynamically.
 
 In Spec 2.0, layouts are by default dynamic and are expressed at the instance level. To allow backward compatibility, it is still possible to define a `defaultLayout` _class_ side method that returns a layout instead of using a `defaultLayout` instance side method but it is not the recommended way.
 
 #### initializePresenters
 
-So far, we have not initialized `filmList`. 
-In fact, `filmList` is a variable pointing to another presenter.
+So far, we have not initialized `filmList`. In fact, `filmList` is a variable holding another presenter.
 
 The place to initialize the subpresenters is in the method `initializePresenters` as shown below. Here we define that `filmList` is a table with three columns. The message `newTable` instantiates a `SpTablePresenter`.
 
 In fact, the list is more a table than a mere list: we describe that we want three columns. This is why we use a table and not a simple list. We define it as follows:
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> initializePresenters
     filmList := self newTable
-        addColumn: (SpStringTableColumn title: 'Name' 
+        addColumn: (SpStringTableColumn title: 'Name'
             evaluated: #name);
         addColumn: (SpStringTableColumn title: 'Director'
             evaluated: #director);
-        addColumn: (SpStringTableColumn title: 'Year' 
+        addColumn: (SpStringTableColumn title: 'Year'
             evaluated: #year);
         yourself
 ```
@@ -134,21 +127,19 @@ ImdbFilmListPresenter >> initializePresenters
 
 ### Filling up the film list
 
-We define the method `updatePresenter` which is automatically invoked after `initializePresenters`. 
-It just queries the domain (`ImdbFilm`) to get the list of the recorded films and populates the internal table with them.
-Right now we do not have any film in the singleton so the list of films is empty.
+We define the method `updatePresenter` which is automatically invoked after `initializePresenters`. It just queries the domain (`ImdbFilm`) to get the list of the recorded films and populates the internal table with them. Right now we do not have any film in the singleton so the list of films is empty.
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> updatePresenter
     filmList items: ImdbFilm films
 ```
 
-The following expression creates an instance of the film list presenter and opens it. 
-You get the widget shown in Figure *@LayoutInitilalizePresenters@*.
+The following expression creates an instance of the film list presenter and opens it. You get the window shown in Figure *@LayoutInitilalizePresenters@*.
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter new open
 ```
+
 If you want, just add manually a film and reopen the presenter and you should see the film in the list.
 
 ```
@@ -164,32 +155,29 @@ ImdbFilm addFilm: (ImdbFilm new
 While directly creating a presenter is possible during development,
 a more canonical way to create a presenter is to ask the application using the message `newPresenter:` as follows.
 
-```language=Smalltalk
+```
 | app |
-app := ImdbApp new. 
+app := ImdbApp new.
 (app newPresenter: ImdbFilmListPresenter) open
 ```
 
-The application is responsible for managing windows and other information, therefore it is important to use it to create presenters that compose the application. 
+The application is responsible for managing windows and other information, therefore it is important to use it to create presenters that compose the application.
 
-### Improving window
+### Improving the window
 
-A presenter can be embedded in another presenter as we will show later. 
-It can be also placed within a window and this is what the message `open` is doing. 
-Spec offers another hook, the method `initializeWindow:` to specialize the information presented when a presenter is displayed within a window. 
+A presenter can be embedded in another presenter as we will show later. It can be also placed within a window and this is what the message `open` is doing. Spec offers another hook, the method `initializeWindow:` to specialize the information presented when a presenter is displayed within a window.
 
 ![Film list presenter with a toolbar and decorated window.](figures/FilmList-02-initalizeWindows.png width=60&label=figFilmListPresenter2)
 
-The method `initializeWindow:` allows you to define a title, a default size (message `initialExtent:`), and a toolbar. 
- 
+The method `initializeWindow:` allows you to define a title, a default size (message `initialExtent:`), and a toolbar.
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> initializeWindow: aWindowPresenter
-    aWindowPresenter 
+    aWindowPresenter
         title: 'Mini IMDB';
         initialExtent: 600@400;
-        toolbar: (self newToolbars
-                    add: (self newToolbarButton 
+        toolbar: (self newToolbar
+                    add: (self newToolbarButton
                             label: 'Add film' ;
                             icon: (self iconNamed: #smallAdd);
                             action: [ self addFilm ];
@@ -200,15 +188,15 @@ ImdbFilmListPresenter >> initializeWindow: aWindowPresenter
 You should obtain the window with a toolbar as shown in Figure *@figFilmListPresenter2@*.
 To make sure that the `Add film` button does not raise an error, we trigger an `addFilm` method
 that is defined with no behavior.
-In fact, we will define a different presenter to be able to define a film. 
+In fact, we will define a different presenter to be able to define a film.
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> addFilm
     "empty for now"
 ```
 
-As we will see with the Commander Chapter, toolbars can be automatically created out of commands.
-We could have added the toolbar in a similar way to the `filmList` (e.g. using an instance variable) as part of the `ImdbFilmListPresenter` because the toolbar is also a presenter (similar to the table presenter or other predefined presenters). But doing this way is less modular.
+As we will see in Chapter *@cha_commander@*, toolbars can be automatically created out of commands.
+We could have added the toolbar in a similar way to the `filmList` (e.g. using an instance variable) as part of the `ImdbFilmListPresenter` because the toolbar is also a presenter (similar to the table presenter or other predefined presenters). But doing it that way is less modular.
 Note also that the toolbar we created could be factored in a separate class to increase reuse too.
 
 
@@ -216,16 +204,15 @@ Note also that the toolbar we created could be factored in a separate class to i
 ### An application manages icons
 
 What we can see from the definition of the previous method `initializeWindow:` is that an application manages also icons via the message `iconNamed:`. Indeed, a presenter defines the `iconNamed:` message as a delegation to its application.
-In addition your application can define its own icon set using the message `iconManager:`. 
+In addition your application can define its own icon set using the message `iconManager:`.
 
 ### FilmPresenter itself
 
 
 We are ready to define a simple presenter to edit a film. We will use it to add a new film or simply display it.
-We create a new subclass of `SpPresenter` named `ImdbFilmPresenter`.
-This class has three instance variables: `nameText`, `directorText`, and `yearNumber`.
+We create a new subclass of `SpPresenter` named `ImdbFilmPresenter`. This class has three instance variables: `nameText`, `directorText`, and `yearNumber`.
 
-```language=Smalltalk
+```
 SpPresenter << #ImdbFilmPresenter
     slots: { #nameText . #directorText . #yearNumber};
     package: 'Spec-TutorialOne'
@@ -233,11 +220,11 @@ SpPresenter << #ImdbFilmPresenter
 
 
 As we did previously, we define a default layout by defining the method `defaultLayout`.
-This time we use a grid layout. With a simple grid layout, you can define the position in the grid where your elements will appear. 
+This time we use a grid layout. With a simple grid layout, you can define the position in the grid where your presenters will appear.
 
-```language=Smalltalk
-ImdbFilmPresenter >> defaultLayout 
-    ^ SpGridLayout new 
+```
+ImdbFilmPresenter >> defaultLayout
+    ^ SpGridLayout new
         add: 'Name' at: 1@1; add: nameText at: 2@1;
         add: 'Director' at: 1@2; add: directorText at: 2@2;
         add: 'Year' at: 1@3; add: yearNumber at: 2@3;
@@ -248,8 +235,8 @@ ImdbFilmPresenter >> defaultLayout
 Note that it is not required to create the accessors for the presenter elements as we were forced to do it in Spec1.0.
 Here we only create getters because we will need them when creating the corresponding `ImbdFilm` instance.
 
-```language=Smalltalk
-ImdbFilmPresenter >> yearNumber
+```
+ImdbFilmPresenter >> year
     ^ yearNumber text
 
 ImdbFilmPresenter >> director
@@ -259,10 +246,10 @@ ImdbFilmPresenter >> name
     ^ nameText text
 ```
 
-For convenience, a `GridLayout` also comes with a builder that lets you add elements to the layout in the order they will appear. The previous layout definition can be rewritten as:
+For convenience, a `SpGridLayout` also comes with a builder that lets you add elements to the layout in the order they will appear. The previous layout definition can be rewritten as:
 
-```language=Smalltalk
-ImdbFilmPresenter >> defaultLayout 
+```
+ImdbFilmPresenter >> defaultLayout
     ^ SpGridLayout build: [ :builder |
         builder 
             add: 'Name'; add: nameText; nextRow;
@@ -274,23 +261,21 @@ Pay attention, do not add a `yourself` message here. Because you would return th
 
 ![A single film presenter.](figures/FilmList-03-OpenFilmPresenter.png width=60&label=figFilmPresenter1)
 
-And similarly, as before, we define the method `initializePresenters` to initialize the variables to the corresponding elementary presenters. 
-Here the `nameText` and `directorText` are initialized to a textInput, and `yearNumber` is a numberInput.
+And similarly, as before, we define the method `initializePresenters` to initialize the variables to the corresponding elementary presenters. Here `nameText` and `directorText` are initialized to a text input, and `yearNumber` is a number input.
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> initializePresenters
     nameText := self newTextInput.
     directorText := self newTextInput.
-    yearNumber := self newNumberInput 
+    yearNumber := self newNumberInput
                 rangeMinimum: 1900 maximum: Year current year;
                 yourself.
 ```
 
 
-Now we can try our little application with the following script and obtain a situation similar to the one displayed by 
-Figure *@figFilmPresenter1@*: 
+Now we can try our little application with the following script and obtain a situation similar to the one shown in Figure *@figFilmPresenter1@*:
 
-```language=Smalltalk
+```
 | app |
 app := ImdbApp new. 
 (app newPresenter: ImdbFilmPresenter) open.
@@ -302,14 +287,14 @@ app := ImdbApp new.
 
 We improve the look of the film presenter by specifying column behavior and setting window properties.
 As you can see, the form to present a Film data has very large labels. Indeed, they take half of the form width.
-We can solve that by using non-homogenous columns and asking the second column to take the biggest possible width (`beExpand`).
+We can solve that by using non-homogenous columns and asking the second column to take the biggest possible width with `column:expand:`. See Figure *@FilmListPresenter2@*
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> defaultLayout
     ^ SpGridLayout build: [ :builder |
         builder
             beColumnNotHomogeneous;
-            column:2 withConstraints: #beExpand;
+            column: 2 expand: true;
             add: 'Name'; add: nameText; nextRow;
             add: 'Director'; add: directorText; nextRow;
             add: 'Year'; add: yearNumber ]
@@ -317,9 +302,9 @@ ImdbFilmPresenter >> defaultLayout
 
 ![Using the non homogenous grid layout.](figures/FilmList-04-OpenFilmPresenter-2.png width=60&label=FilmListPresenter2)
 
-We now set the window properties by adding the following new `initializeWindow:` method (See Figure *@FilmListPresenter3@*).
+We now set the window properties by adding the following new `initializeWindow:` method. See Figure *@FilmListPresenter3@*.
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> initializeWindow: aWindowPresenter
     aWindowPresenter
         title: 'Film';
@@ -333,10 +318,10 @@ ImdbFilmPresenter >> initializeWindow: aWindowPresenter
 Spec lets us adapt the dialog window, for example, to add interaction buttons.
 Here we specialize the method `initializeDialogWindow:` to add two buttons that control the behavior of the application (as shown in Figure *@Customizeddialog@*).
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> initializeDialogWindow: aDialogPresenter
     aDialogPresenter centered.
-    aDialogPresenter 
+    aDialogPresenter
         addButton: 'Cancel' do: [ :presenter | presenter close ];
         addButton: 'Save Film' do: [ :presenter | presenter beOk; close ].
 ```
@@ -346,15 +331,12 @@ ImdbFilmPresenter >> initializeDialogWindow: aDialogPresenter
 
 ### Invoking a presenter
 
-We are ready to use the film presenter from the film list presenter. 
-We can define the method `addFilm` in the class `ImdbFilmListPresenter`. 
-When the user clicks on the button, we create a new film presenter that we associate with the current application. 
+We are ready to use the film presenter from the film list presenter. We can define the method `addFilm` in the class `ImdbFilmListPresenter`. When the user clicks on the button, we create a new film presenter that we associate with the current application.
 
-We open such a presenter as a modal dialog using the message `openModal`.
-When the user press the Ok button (that we have customized in Figure *@FilmListPresenter3@*), we add a new film
+We open such a presenter as a modal dialog using the message `openModal`. When the user presses the "Save Film" button (that we have customized in Figure *@Customizeddialog@*), we add a new film
 to our little database and we update the list as shown in Figure *@refreshed@*.
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> addFilm
     | presenter windowPresenter |
     presenter := ImdbFilmPresenter newApplication: self application.
@@ -366,16 +348,15 @@ ImdbFilmListPresenter >> addFilm
             (ImdbFilm new
                 name: presenter name;
                 director: presenter director;
-                year: presenter yearNumber).
+                year: presenter year).
     self updatePresenter
 ```
 
 
-We can now open the `FilmListPresenter` and click on the `Add film` button. Once the film data entered, and the `Save Film` button clicked,
-you will see that the FilmListPresenter is updated with the film we just added.
+We can now open the `FilmListPresenter` and click on the `Add film` button. Once the film data entered, and the `Save Film` button clicked, you will see that the FilmListPresenter is updated with the film we just added.
 
-```language=Smalltalk
-app := ImdbApp new. 
+```
+app := ImdbApp new.
 (app newPresenter: ImdbFilmListPresenter) open.
 ```
 
@@ -384,24 +365,22 @@ app := ImdbApp new.
 
 ### Embedding a FilmPresenter into the FilmList
 
-We have two main visual elements:  one for a list of films and one for film details.
-We can imagine that we would like to see the film details in the same
-container as the list, especially since a film description should be larger than the list columns. 
+We have two main visual elements:  one for a list of films and one for film details. We can imagine that we would like to see the film details in the same container as the list, especially because a film description is larger than the list columns.
 
 Let us proceed. First, we add a new instance variable named `detail` to the class `ImdbFilmListPresenter`.
 
-```language=Smalltalk
+```
 SpPresenter << #ImdbFilmListPresenter
-    slots: { #filmList . #detail};
+    slots: { #filmList . #detail };
     package: 'Spec-TutorialOne'
 ```
 
 We redefine the default layout. We will show later that we can have different layouts.
 
-```language=Smalltalk
-ImdbFilmListPresenter >> defaultLayout 
+```
+ImdbFilmListPresenter >> defaultLayout
     ^ SpBoxLayout newTopToBottom
-        add: filmList; 
+        add: filmList;
         add: detail;
         yourself
 ```
@@ -409,7 +388,7 @@ ImdbFilmListPresenter >> defaultLayout
 
 Finally, since we are going to use this presenter in different places, we will need to add a method to control whether it is editable or not:
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> editable: aBoolean
     nameText editable: aBoolean.
     directorText editable: aBoolean.
@@ -418,31 +397,32 @@ ImdbFilmPresenter >> editable: aBoolean
 
 Now we improve the `initializePresenters` of `ImdbFilmListPresenter`.
 - First we instantiate `ImdbFilmPresenter`.
-- Second, we configure it as read-only sending the `editable: false` message. 
-- Third we define that, when an element of the list is selected, we should display the information in the detail presenter. While we can express this in the `initializePresenters` method, we prefer to specify it in the `connectPresenters` method below.
+- Second, we configure it as read-only by sending the `editable: false` message.
+- Third we define that, when an element of the list is selected, we should display the information in the detail presenter. While we can express this in the `initializePresenters` method, we prefer to specify it in the `connectPresenters` method. See section *@section_define_component_communication@*.
 
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> initializePresenters
     filmList := self newTable
-        addColumn: (SpStringTableColumn title: 'Name' 
+        addColumn: (SpStringTableColumn title: 'Name'
              evaluated: #name);
         addColumn: (SpStringTableColumn title: 'Director'
               evaluated: #director);
         addColumn: (SpStringTableColumn title: 'Year'
              evaluated: #year);
         yourself.
-        
+
     detail := self instantiate: ImdbFilmPresenter.
     detail editable: false
 ```
 
 ### Define component communication
+@section_define_component_communication
 
 We add a little helper method named `setModel:` in class `ImdbFilmPresenter` to be able to pass a film
 and populate the presenter accordingly. We will use this method in the following method.
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> setModel: aFilm
     nameText text: aFilm name.
     directorText text: aFilm director.
@@ -451,26 +431,25 @@ ImdbFilmPresenter >> setModel: aFilm
 
 Note that the method `setModel:` is needed only if you do not subclass from `SpPresenterWithModel`. If you subclass from `SpPresenter`, it is the only way to have the model initialized before the setup of the presenter (and avoid errors when opening the presenter).
 
-Defining interactions between presenters is done in the `connectPresenters` method. We implement it to define that, when an element of the list is selected, we should display the information in the detail presenter.
-It is worth taking some time to look at `whenSelectionChangedDo:` message.
+Defining interactions between presenters is done in the `connectPresenters` method. We implement it to define that, when an element of the list is selected, we should display the information in the detail presenter. It is worth taking some time to look at the `whenSelectionChangedDo:` message.
 
-The `whenSelectionChangedDo:` method expects a block with zero or one argument. Such an argument is not the selected item directly but a more complex object that represents the selection. Indeed a selection is different in a single item selection list and a multiple selection list. Therefore Spec 2,0 defines the notion of selection mode under the form of subclasses of `SpAbstractSelectionMode`.
+The `whenSelectionChangedDo:` method expects a block with zero or one argument. Such an argument is not the selected item directly but a more complex object that represents the selection. Indeed a selection is different in a single selection list and a multiple selection list. Therefore Spec 2,0 defines the notion of selection mode under the form of subclasses of `SpAbstractSelectionMode`.
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> connectPresenters
-    filmList whenSelectionChangedDo: [ :selectedItemMode | 
-        selectedItemMode isEmpty 
+    filmList whenSelectionChangedDo: [ :selectedItemMode |
+        selectedItemMode isEmpty
              ifFalse: [ detail setModel: selectedItemMode selectedItem ] ].
 ```
 
+With `connectPresenters` in place, selecting an item in the list results in showing the details of the selected item, as shown in Figure *@embedded@*.
 
 ![Embedding the film description in the list: selecting a list item populates the detailed visual component.](figures/FilmList-07-embedded.png width=60&label=embedded)
 
 
 ### Testing your application UI
 
-A strong aspect of Spec is the fact that we can write tests about the interaction and the logic of your UI.
-And tests are so powerful to help us create nice designs and make sure that we can spot our errors that we give you the chance to see that writing tests for UI is not complex.
+A strong aspect of Spec is the fact that we can write tests about the interaction and the logic of your UI. Tests are so powerful to help us create nice designs and make sure that we can spot our errors, that we give you the chance to see that writing tests for a UI is not complex.
 
 We define a subclass of `TestCase`.
 
@@ -503,20 +482,19 @@ As you see, we will need to define two methods on `ImdbFilmListPresenter` to sup
 We categorize them in a `testing - support` protocol to show they are only useful for testing purposes.
 
 ```
-ImdbFilmListPresenter >> clickFilmAtIndex: anIndex 
+ImdbFilmListPresenter >> clickFilmAtIndex: anIndex
     filmList clickAtIndex: anIndex
 
 ImdbFilmListPresenter >> detail
     ^ detail
 ```
 
-This test is a bit poor because we do not test explicit the value of the name of the film in the detailled component. 
-We did this to keep the test set up simple, partly because `ImdbFilm` stores globally the current films (Singletons are ugly and they also make testing more complex).
+This test is a bit poor because we do not test explicitly the value of the name of the film in the detailled component. We did this to keep the test set up simple, partly because `ImdbFilm` stores the current films globally (Singletons are ugly and they also make testing more complex).
 
-We define three helper methods on ImdbFilm to reset the stored films and add E.T. film.
+We define three helper methods on ImdbFilm to reset the stored films and add the E.T. film.
 
 ```
-ImdbFilm class >> reset 
+ImdbFilm class >> reset
     films := OrderedCollection new
 ```
 
@@ -529,10 +507,10 @@ ImdbFilm class >> addET
 
 ```
 ImdbFilm class >> ET
-    ^ self new 
+    ^ self new
         name: 'E.T.';
         director: 'Steven Spielberg';
-        year: '1982'; 
+        year: '1982';
         yourself
 ```
 
@@ -541,8 +519,8 @@ Now we can define a method `setUp`.
 
 ```
 FilmListPresenterTest >> setUp
-    super setUp. 
-    ImdbFilm reset. 
+    super setUp.
+    ImdbFilm reset.
     ImdbFilm addET
 ```
 
@@ -567,13 +545,13 @@ FilmListPresenterTest >> testWhenSelectingOneFilmThenDetailIsUpdated
 
 ```
 FilmListPresenterTest >> tearDown
-    presenter ifNotNil: [ presenter delete ].
+    presenter delete.
     super tearDown
 ```
 
 ### Adding more tests
 
-Tests are addictive -- because we can change programs and check that they still work and limit our stress.
+Tests are addictive because we can change programs and check that they still work and limit our stress.
 So we will write another one.
 
 Let us add the following getter method to support our tests.
@@ -597,7 +575,7 @@ FilmListPresenterTest >> testWhenSelectingOneFilmAndClickingOnEmpty
 
     "Assert"
     name := presenter detail name.
-    self deny:  name isEmpty. 
+    self deny: name isEmpty.
     self assert: presenter filmList listSize equals: 1.
 
     presenter clickFilmAtIndex: 2.
@@ -605,36 +583,36 @@ FilmListPresenterTest >> testWhenSelectingOneFilmAndClickingOnEmpty
 ```
 
 
-Since we do not really understand what would be to set the list as multiple selection we test it. 
+Since we do not really understand what would be to set the list as multiple selection we test it.
 
 ```
 FilmListPresenterTest >> testListIsSimpleSelection
-    presenter := ImdbFilmListPresenter new.    
+    presenter := ImdbFilmListPresenter new.
     presenter open.
     self deny: presenter filmList isMultipleSelection
 ```
 
 
-What you see is that it relatively simple to test that the interaction you specified is actually working as expected. 
+What you see is that it relatively simple to test that the interaction you specified is actually working as expected.
 
 
-### Changing layout 
+### Changing layout
 
 With Spec, a presenter can have multiple layouts and even layouts that are created on the fly as we will see with dynamic layouts. We can decide which layout to use to open a presenter. Let us illustrate it. Imagine that we prefer to have the list above the film details or just the list alone.
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> listAboveLayout
     ^ SpBoxLayout newTopToBottom
         add: detail;
-        add: filmList; 
+        add: filmList;
         yourself
 ```
 
 The following example shows that we can open `ImdbFilmListPresenter` with the layout `listAboveLayout` that we just defined.
 
-```language=Smalltalk
+```
 | app presenter |
-app := ImdbApp new. 
+app := ImdbApp new.
 presenter := app newPresenter: ImdbFilmListPresenter.
 presenter openWithLayout: presenter listAboveLayout.
 ```
@@ -642,61 +620,57 @@ presenter openWithLayout: presenter listAboveLayout.
 We can also define a layout with a part of the subpresenters.
 Here `listOnlyLayout` only shows the list.
 
-```language=Smalltalk
-ImdbFilmListPresenter >> listOnlyLayout 
+```
+ImdbFilmListPresenter >> listOnlyLayout
     ^ SpBoxLayout newTopToBottom
-        add: filmList; 
+        add: filmList;
         yourself
 ```
 
 The following example shows that we can open `ImdbFilmListPresenter` with one layout and dynamically change it by another layout.
 In the playground do not declare the temporary variables so that they are bound and kept in the playground.
 
-```language=Smalltalk
-app := ImdbApp new. 
+```
+app := ImdbApp new.
 presenter := app newPresenter: ImdbFilmListPresenter.
 presenter open.
 ```
 
-The presenter is opened with the default layout, now in the playground execute the following line. 
+The presenter is opened with the default layout, now in the playground execute the following line.
 
-```language=Smalltalk
+```
 presenter layout: presenter listOnlyLayout.
 ```
 
-You can now see that the layout showing only one list has been applied dynamically.
+Now you can see that the layout with only one list has been applied dynamically.
 
-![A presenter can have multiple layouts for its subpresenters.](figures/FilmList-08-embeddedAbove.png width=60&label=embedded)
+![A presenter can have multiple layouts for its subpresenters.](figures/FilmList-08-embeddedAbove.png width=60&label=changedlayout)
 
-    
+
 ### Using transmissions
 
-Spec 2.0 introduces a nice optional concept to propagate selection from one presenter to another, thinking on the "flow" of information more than the implementation details of this propagation, which can change from presenter to presenter.
+Spec 2.0 introduces a nice optional concept to propagate selection from one presenter to another, thinking about the "flow" of information more than the implementation details of this propagation, which can change from presenter to presenter.
 
 With transmissions, each presenter can define a set of output ports (ports to transmit information) and input ports (ports to receive information). Widget presenters already have defined the output/input ports you can use with them, but you can add your own ports to your presenters.
 
 The easiest way to declare a transmission is by sending the `transmitTo:` message from one presenter to another. We can now update the `connectPresenters` method to use transmissions.
 
-```language=Smalltalk
+```
 ImdbFilmListPresenter >> connectPresenters
-    "Transmitting from my filmList to detail"
     filmList transmitTo: detail.
 ```
 
 Here, `filmList` is a table that will transmit its selection to `detail` presenter.
 
-    
-Let us explain a bit. `ImdbFilmPresenter` is a custom presenter. Spec does not know how to "fill" it with input data. 
-We need to tell Spec that `ImdbFilmPresenter` model will be the input port and receive the input data. 
-Therefore we need to define an input port as follows: 
+Let us explain a bit. `ImdbFilmPresenter` is a custom presenter. Spec does not know how to "fill" it with input data. We need to tell Spec that `ImdbFilmPresenter` model will be the input port and receive the input data. Therefore we need to define an input port as follows:
 
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> inputModelPort
     ^ SpModelPort newPresenter: self
 ```
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> defaultInputPort
     ^ self inputModelPort
 ```
@@ -707,9 +681,9 @@ Note that we could have inlined `inputModelPort` definition into the `defaultInp
 The input data will be set by using the `setModel:` method we already defined on `ImdbFilmPresenter`.
 
 You can now open the application and see that it still behaves as expected.
-```language=Smalltalk
+```
 | app |
-app := ImdbApp new. 
+app := ImdbApp new.
 (app newPresenter: ImdbFilmListPresenter) open.
 ```
 
@@ -718,26 +692,16 @@ app := ImdbApp new.
 
 ### Styling the application
 
-Different elements in an application can have different looks and feel, for example to change the size or color of a font for a header. 
-To support this, Spec introduces the concept of "styles" for components. 
+Different elements in an application can have different look and feels, for example to change the size or color of a font for a header. To support this, Spec introduces the concept of "styles" for components.
 
-In Spec, one application defines a Stylesheet (or a set of them). 
-This defines a set of "style classes" that can be later assigned to presenter widgets. 
-Defining a style class, however, works differently for each backend. 
-While Gtk accepts (mostly) regular CSS to style your widgets, Morphic has its own sub-framework. 
+In Spec, an application defines a Stylesheet (or a set of them). This defines a set of "style classes" that can be later assigned to presenter widgets. Defining a style class, however, works differently for each backend. While Gtk accepts (mostly) regular CSS to style your widgets, Morphic has its own sub-framework.
 
-An application comes with a default configuration and a default style sheet. 
-If you do not need to style your application, there is no need to define them.
-In our example, we would like to define a `header` style to customize some labels. 
-In Spec every presenter understands the message `addStyle:` that adds a tag (a CSS class) to the receiver. 
+An application comes with a default configuration and a default stylesheet. If you do not need to style your application, there is no need to define them. In our example, we would like to define a `header` style to customize some labels. In Spec every presenter understands the message `addStyle:` that adds a tag (a CSS class) to the receiver.
 
 
-To do so, you need to declare a stylesheet in a configuration. 
-The configuration itself needs to be declared in your application.
-Then we will define a new presenter for the label and tag it with a specific CCS class using the message `addStyle:`.
-Our class will be named `'customLabel'`. 
+To do so, you need to declare a stylesheet in a configuration. The configuration itself needs to be declared in your application. We will define a new presenter for the label and tag it with a specific CCS class using the message `addStyle:`. Our CCS class will be named `'customLabel'`.
 
-So let us start, we create the specific configuration for our application.
+First, we create the specific configuration for our application.
 
 ```
 SpMorphicConfiguration << #ImdbConfiguration
@@ -745,27 +709,26 @@ SpMorphicConfiguration << #ImdbConfiguration
 ```
 
 
-```language=Smalltalk
+```
 ImdbApp >> initialize
 
      super initialize.
     self
-        useBackend: #Morphic 
+        useBackend: #Morphic
         with: ImdbConfiguration new.
 ```
 
-We can now define our custom styles.
-The easiest way is to create a style from a String. Here we define that an element using the tag `customLabel` will be drawn in red.
+We can now define our custom styles. The easiest way is to create a style from a String. Here we define that an element using the tag `customLabel` will be drawn in red.
 
 ```
 ImdbConfiguration >> customStyleSheet
     ^ '
-.application [ 
-    .customLabel [ Draw { #color: #red } ] ] ')
+.application [
+    .customLabel [ Font { #color: #red } ] ]'
 ```
 
 Pay attention not to forget the '.' in front of `application` and `customLabel`
-We specialize the method `configure:` so that it includes the custom style as follows: 
+We specialize the method `configure:` so that it includes the custom style as follows:
 
 ```
 ImdbConfiguration >> configure: anApplication
@@ -776,30 +739,30 @@ ImdbConfiguration >> configure: anApplication
 
 We are ready to use the tag for the label.
 Up until now, Spec was creating automatically a presenter for the label but it was not accessible from the developer. 
-Therefore we have to add a label explicitly so that we can tag it with a 'CSS' like class. This is what the message `addStyle: 'customLabel'` below is doing.  
+Therefore we have to add a label explicitly so that we can tag it with a 'CSS' like class. This is what the message `addStyle: 'customLabel'` below is doing.
 
-We add a `nameLabel` instance variable to `ImdbFilmPresenter` to get a label and we initialize it in the method `initializePresenters` as follows: 
+We add a `nameLabel` instance variable to `ImdbFilmPresenter` to get a label and we initialize it in the method `initializePresenters` as follows:
 
-```language=Smalltalk
-ImdbFilmPresenter >> initializePresenters 
-    nameLabel := self newLabel 
-        label: 'Name'; 
-        addStyle: 'customLabel'; 
+```
+ImdbFilmPresenter >> initializePresenters
+    nameLabel := self newLabel
+        label: 'Name';
+        addStyle: 'customLabel';
         yourself.
     nameText := self newTextInput.
     directorText := self newTextInput.
-    yearNumber := self newNumberInput 
+    yearNumber := self newNumberInput
             rangeMinimum: 1900 maximum: Year current year;
             yourself.
 ```
 
 
 
-We then update the layout to use the newly defined label presenter.
+Then we update the layout to use the newly defined label presenter.
 
-```language=Smalltalk
+```
 ImdbFilmPresenter >> defaultLayout
-    
+
     ^ SpGridLayout build: [ :builder |
         builder
             beColumnNotHomogeneous;
@@ -818,5 +781,4 @@ We can now see that the name label of a film detail has been styled.
 ### Conclusion
 
 We saw that with Spec the developer defines how a visual element (a presenter) is composed of other visual elements. 
-Such a presenter has the responsibility to describe the interaction with other presenters but also with the domain objects. 
-It has also the responsibility to describe its visual aspect.
+Such a presenter has the responsibility to describe the interaction with other presenters but also with the domain objects. It has also the responsibility to describe its visual aspect.

--- a/Chapters/Commander2/Commander.md
+++ b/Chapters/Commander2/Commander.md
@@ -1,1 +1,611 @@
-## Commander: A Powerful and Simple Command Frameworkstatus: Ready for review should publish the codestatus: spellcheckedCommander was a library originally developed by Denis Kudriashov. Commander 2.0 is the second iteration of such a library. It was designed and developed by Julien Delplanque and Stéphane Ducasse.Note that Commander 2.0 is not compatible with Commander but this is really easy to migrate from Commander to Commander 2.0.We describe Commander 2.0 in the context of Spec 2.0, the user interface building framework.From then on, when we mention Commander we refer to Commander 2.0.In addition, we show how to extend Commander to other needs.### CommandsCommander models application actions as first-class objects following the Command design pattern.With Commander, you can express commands and use them to generate menus, and toolbar but also to script an application from the command line.Every action is implemented as a separate command class \(subclass of `CmCommand`\) with an `execute` method and all states required for execution.The superclass defines the context in which the command should be executed. Then the class `CmCommand` introduces the name and description.![A simple command and its hierarchy.](figures/BasicCommand.pdf width=35&label=first)We will show later that for UI framework, we need more information such as an icon and shortcut description.In addition, we will present how commands can be decorated with extra functionality in an extensible way.Note that nothing prevents you from defining commands by creating instances and filling them up with the same information.If you do so, you cannot use classes to dispatch and should put in place other mechanisms. In this chapter, we only discuss how to define classes representing commands and use them. ### Defining commandsA command is a simple object instance of a subclass of the class `CmCommand`.It has a description, a name \(this name can be either static or dynamic as we will show later on\). In addition, it has a context from which it extracts information to execute itself. In its basic form, there is not much more than that.Let us have a look at examples. We will define some commands for the ContactBook application and illustrate how they can be turned into menu and menubar.Note that we will present how Commander supports Spec menu and menubar creations.However such functionalities are not in the core of Commander.We show them because first, this is important to illustrate how to build user interface elements with Commander but also because such functionalities show that Commander can be extended in a way that end-users do not have to feel they are using special extensions.We will come back to such a point in the last chapter of this book to show potential extenders of Commander that they can get inspiration from the Spec extensions.### Adding some convenience methodsFor convenience reasons, we define a common superclass to all the commands of the contact book application named `EgContactBookCommand`.```CmCommand << #EgContactBookCommand    package: 'EgContactBook'```We define a simple helper method to make the code more readable```EgContactBookCommand >> contactBookPresenter    ^ self context```For the same reason, we define another helper to access the contact book and the selected item.```EgContactBookCommand >> contactBook    ^ self contactBookPresenter contactBook``````EgContactBookCommand >> selectedContact    ^ self contactBookPresenter selectedContact```Using such helper methods we defined the method `hasSelectContract` as follows:```EgContactBookCommand >> hasSelectedContact    ^ self contactBookPresenter isContactSelected```#### Adding the add contact commandWe define a subclass to define the add a contact command. ```EgContactBookCommand << #EgAddContactCommand    package: 'EgContactBook'``````CmAddContactCommand >> initialize    super initialize.    self        basicName: 'New contact';         basicDescription: 'Creates a new contact and add it to the contact book.'``````CmAddContactCommand >> execute        | contact |    contact := self contactBookPresenter newContact.    self hasSelectedContact        ifTrue: [ self contactBook addContact: contact after: self selectedContact ]        ifFalse: [ self contactBook addContact: contact ].            self contactBookPresenter updateView```We should define the method `updateView` to refresh the contents of the table.```EgContactBookPresenter >> updateView    table items: contactBook contacts```Now in the inspect pane, we can simply execute the command as follows:```(EgAddContactCommand new context: self) execute```Executing the command should ask you to give a name and a phone numberand will get added to the list.We can also execute the following snippet.```| presenter cmd |presenter := EgContactBookPresenter on: EgContactBook coworkers.cmd := EgAddContactCommand new context: presenter.cmd execute```### Adding the remove contact commandWe define now another command to remove a command. This example is interesting because it does not involve any UI interaction.It shows that a command is not necessarily linked to UI interaction.```EgContactBookCommand << #EgRemoveContactCommand    package: 'EgContactBook'``````EgRemoveContactCommand >> initialize    super initialize.    self        name: 'Remove';         description: 'Removes the selected contact from the contact book.'```This command definition illustrates how we can control when a command should or not be executed. The method `canBeRun` allows one to specify such a condition.```EgRemoveContactCommand >> canBeExecuted    ^ self context isContactSelected```The method `execute` is straightforward.```EgRemoveContactCommand >> execute    self contactBook removeContact: self selectedContact.    self contactBookPresenter updateView```The following test validates the correct execution of the command.```EgContactCommandTest >> testRemoveContact    self assert: presenter contactBook size equals: 3.    presenter table selectIndex: 1.    (EgRemoveContactCommand new context: presenter) execute.    self assert: presenter contactBook size equals: 2```### Turning commands into menu itemsNow that we have our commands we would like to reuse them and turn them into menus. In Spec, commands that are transformed into menu items are structured into a tree of command instances. The class method `buildCommandsGroupWith:forRoot:` of `SpPresenter` is a hook to let presenters define the root of the command instance tree.A command is transformed into a command for Spec using the message `forSpec`.We will show later that we can add UI-specific information to a command such as an icon and a shortcut.The method `buildCommandsGroupWith:forRoot:` registers commands to which the presenter instance is passed as context. Note that here we just add plain commands, but we can also create groups. This is also in this method that we will specify a toolbar.```EgContactBookPresenter class >>     buildCommandsGroupWith: presenter     forRoot: rootCommandGroup        rootCommandGroup         register: (EgAddContactCommand forSpec context: presenter);        register: (EgRemoveContactCommand forSpec context: presenter)```We now have to attach the root of the command tree to the table. This is what we do with the new line in the `initializePresenters` method. Notice that we have full control and as we will show we could select a subpart of the tree \(using the message `/`\) and define it as root for a given component.```EgContactBookPresenter >> initializePresenters    table := self newTable.    table         addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);        addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).    table contextMenu: [ self rootCommandsGroup beRoot asMenuPresenter ].    table items: contactBook contacts.```Reopening the interface `(EgContactBookPresenter on: EgContactBook coworkers) openWithSpec` you should see the menu items as shown in Figure *@withmenu@*.As we will show later we could even replace a menu item with another one, changing its name, or icon in place.![With two menu items with groups.](figures/withMenus.png width=60&label=withmenu)### Introducing groupsCommands can be managed in groups and such groups can be turned into corresponding menu item sections.The key hook method is the class method named `buildCommandsGroupWith: presenterInstance forRoot:`.Here we give an example of such grouping. Note that the message `asSpecGroup` sent to a group.We create two methods creating each a simple group one for adding and one for removing contracts.```EgContactBookPresenter class >> buildAddingGroupWith: presenter    ^ (CmCommandGroup named: 'Adding') asSpecGroup        description: 'Commands related to contact addition.';        register: (EgAddContactCommand forSpec context: presenter);        beDisplayedAsGroup;        yourself``````EgContactBookPresenter class >> buildRemovingGroupWith: presenter    ^ (CmCommandGroup named: 'Removing') asSpecGroup        description: 'Commands related to contact removal.';        register: (EgRemoveContactCommand forSpec context: presenter);        beDisplayedAsGroup;        yourself```We group the previously defined groups together under the contextual menu for example. ```EgContactBookPresenter class >> buildContextualMenuGroupWith: presenter    ^ (CmCommandGroup named: 'Context Menu') asSpecGroup        register: (self buildAddingGroupWith: presenter);        register: (self buildRemovingGroupWith: presenter);        yourself```Finally, we revisit the hook `buildCommandsGroupWith:forRoot:` to register the last group to the root command group.```EgContactBookPresenter class >>     buildCommandsGroupWith: presenter     forRoot: rootCommandGroup        rootCommandGroup        register: (self buildContextualMenuGroupWith: presenter)```Reopening the interface `(EgContactBookPresenter on: EgContactBook coworkers) openWithSpec` you should see the menu items inside a `'Context Menu'` as shown in Figure *@withmenuContext@*.![With a context menu.](figures/withmenuContext.png width=60&label=withmenuContext)To show you that we can also select a part of the command tree we select the `'Context Menu'` group and declare it as the root of the table menu.In such case, you will not see the `'Context Menu'` anymore. ```EgContactBookPresenter >> initializePresenters    table := self newTable.    table         addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);        addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).        table contextMenu: [ (self rootCommandsGroup / 'Context Menu') beRoot asMenuPresenter ].    table items: contactBook contacts```### Extending menusBuilding a menu is nice, but sometimes we need to add a menu to an existing one. Commander supports this via a dedicated pragma, called `<extensionCommands>` that identifies extensions. as we show it now. Imagine that we have new functionality that we want to add to the contact book and that this behavior is packaged in another package, here, `EgContactBook-Extensions`.First, we will define a new command and second, we will show how we can extend the existing menu to add a new menu item. ```EgContactBookCommand << #EgChangePhoneCommand    slots: { #newPhone};    package: 'EgContactBook-Extensions'``````EgChangePhoneCommand >> newPhone: anObject    newPhone := anObject``````EgChangePhoneCommand >> newPhone    ^ newPhone ``````EgChangePhoneCommand >> initialize    super initialize.    self        name: 'Change phone';        description: 'Change the phone number of the contact.'``````EgChangePhoneCommand >> execute    self selectedContact phone: self contactBookPresenter newPhone.    self contactBookPresenter updateView```We add `ContactBookPresenter` with the method `newPhone` the presenter to support the definition of the new phone number. The point here is not that this is method is or not packaged with the new command.```EgContactBookPresenter >> newPhone    | phone |    phone := self         request: 'New phone for the contact'        initialAnswer: self selectedContact phone         title: 'Set new phone for contact'.    (phone matchesRegex: '\d\d\d\s\d\d\d')        ifFalse: [             SpInvalidUserInput signal: 'The phone number is not well formatted. Should match "\d\d\d\s\d\d\d"' ].    ^ phone```The last missing piece is the declaration of the extension.This one is done using the pragma `<extensionCommands>` on the class side of the presenter class as follows:Here we see that using slash \(` / `\), we can select the group in which we want to add the item.```EgContactBookPresenter class >>     changePhoneCommandWith: presenter     forRootGroup: aRootCommandsGroup        <extensionCommands>        (aRootCommandsGroup / 'Context Menu')        register: (EgChangePhoneCommand forSpec context: presenter)```![With menu extension.](figures/withmenuExtension.png width=60&label=withmenuExtension)### Managing icons and shortcutsBy default a command does not know about Spec-specific behavior, this is because a command does not have to be linked to UI.Now obviously you want to have icons and shortcut bindings when you are designing an interactive application.Commander supports the addition of icons and shortcut keys to commands.Let us see how it works from a user perspective. The framework offers two methods to set icon and shortcut key: `iconName:` and `shortcutKey:`.We should specialize the method `aSpecCommand` as follows: ```EgRemoveContactCommand >> asSpecCommand    ^ super asSpecCommand        iconName: #removeIcon;        shortcutKey: $x meta;        yourself``````EgRemoveContactCommand >> asSpecCommand    ^ super asSpecCommand        shortcutKey: $n meta;        iconName: #changeAdd;        yourself```Note that the commands are created using the message `forSpec` and this is this message that takes care of the calling of `asSpecCommand`.### Enabling shortcutsTo the time of this chapter writing, Commander management of shortcuts has not been pushed to Spec to avoid dependency on Commander. It is then the responsibility of your presenter to manage shortcuts as shown in the following method.We ask the command group to install the shortcut handler in the window.```EgContactBookPresenter >> initializeWindow: aWindowPresenter        super initializeWindow: aWindowPresenter.    self rootCommandsGroup installShortcutsIn: aWindowPresenter```### In-place customisationCommander supports also the reuse and in-place customisation of commands.It means that the instance representing a command can be modified on the spot: for example, its name or description can be adapted to the exact use context.Here is an example that shows that we adapt twice the same command.Let us define a really simple and generic command that will simply inspect the object. ```EgContactBookCommand << #EgInspectCommand    package: 'EgContactBook-Extensions'``````EgInspectCommand >> initialize    super initialize.    self        name: 'Inspect';        description: 'Inspect the context of this command.'``````EgInspectCommand >> execute    self context inspect```Using a block the context is computed at the moment the command is executed and the name and description can be adapted for its specific usage as shown in Figure *@inPlaceCustomisation@*.```EgContactBookPresenter class >>        extraCommandsWith: presenter     forRootGroup: aRootCommandsGroup        <extensionCommands>        aRootCommandsGroup / 'Context Menu'        register:            ((CmCommandGroup named: 'Extra') asSpecGroup                description: 'Extra commands to help during development.';                register:                    ((EgInspectCommand forSpec context: [ presenter selectedContact ])                        name: 'Inspect contact';                        description: 'Open an inspector on the selected contact.';                        iconName: #smallFind;                        yourself);                register:                    ((EgInspectCommand forSpec context: [ presenter contactBook ])                        name: 'Inspect contact book';                        description: 'Open an inspector on the contact book.';                        yourself);                yourself)```![With menu extension.](figures/inPlaceCustomisation.png width=95&label=inPlaceCustomisation)### Managing a menu barCommander supports also menu bar creation.The logic is the same as for contextual menus: we define a group and register it under a given and we specify to the presenter to use this group as a menubar.Imagine that we have a new command to print the contact.```EgContactBookCommand << #EgPrintContactCommand    package: 'EgContactBook'``````EgPrintContactCommand >> initialize    super initialize.    self        name: 'Print';        description: 'Print the contact book in Transcript.'    ``````EgPrintContactCommand >> execute    Transcript open.    self contactBook contacts do: [ :contact | self traceCr: contact name , ' - ' , contact name ]```We create a simple group that we call 'MenuBar' \(but it could be called anything\).```EgContactBookPresenter class >> buildMenuBarGroupWith: presenter    ^ (CmCommandGroup named: 'MenuBar') asSpecGroup        register: (EgPrintContactCommand forSpec context: presenter);        yourself```We modify the root to get the menu bar group in addition to the previous ones. ```EgContactBookPresenter class >>     buildCommandsGroupWith: presenter     forRoot: rootCommandGroup        rootCommandGroup        register: (self buildMenuBarGroupWith: presenter);        register: (self buildContextualMenuGroupWith: presenter)```And we hook it into the widget as the last line of the `initializePresenters` method. Notice the use of the message `asMenuBarPresenter` and the addition of a new instance variable called `menuBar`.```EgContactBookPresenter >> initializePresenters    table := self newTable.    table         addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);        addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).    table contextMenu: [ (self rootCommandsGroup / 'Context Menu') beRoot asMenuPresenter ].    table items: contactBook contents.    menuBar := (self rootCommandsGroup / 'MenuBar') asMenuBarPresenter.```Finally, to get the menu bar you should declare it in the layout.```EgContactBookPresenter class >> defaultSpec    ^ SpBoxLayout newVertical            add: #menuBar            withConstraints: [ :constraints | constraints height: self toolbarHeight ];            add: #table;             yourself```![With menubar.](figures/withmenubar.png width=60&label=inPlaceCustomisation)### ConclusionIn this chapter, we saw how you can define a simple command and execute it in a given context. We show how you can turn a command into a menu item in Spec20 by sending the message `forSpec`. You learned how we can reuse and customize commands. We presented groups of commands as a way to structure menus and menubars. 
+## Commander: A Powerful and Simple Command Framework
+@cha_commander
+
+status: Ready for review should publish the code
+status: spellchecked
+
+Commander was a library originally developed by Denis Kudriashov. 
+Commander 2.0 is the second iteration of such a library. 
+It was designed and developed by Julien Delplanque and Stéphane Ducasse.
+Note that Commander 2.0 is not compatible with Commander but this is really easy to migrate from Commander to Commander 2.0.
+We describe Commander 2.0 in the context of Spec 2.0, the user interface building framework.
+From then on, when we mention Commander we refer to Commander 2.0.
+In addition, we show how to extend Commander to other needs.
+
+
+
+### Commands
+
+
+Commander models application actions as first-class objects following the Command design pattern.
+With Commander, you can express commands and use them to generate menus, and toolbar but also to script an application from the command line.
+
+Every action is implemented as a separate command class \(subclass of `CmCommand`\) with an `execute` method and all states required for execution.
+The superclass defines the context in which the command should be executed. 
+Then the class `CmCommand` introduces the name and description.
+
+![A simple command and its hierarchy.](figures/BasicCommand.pdf width=35&label=first)
+
+We will show later that for UI framework, we need more information such as an icon and shortcut description.
+In addition, we will present how commands can be decorated with extra functionality in an extensible way.
+
+Note that nothing prevents you from defining commands by creating instances and filling them up with the same information.
+If you do so, you cannot use classes to dispatch and should put in place other mechanisms. 
+In this chapter, we only discuss how to define classes representing commands and use them. 
+
+### Defining commands
+
+A command is a simple object instance of a subclass of the class `CmCommand`.
+It has a description, a name \(this name can be either static or dynamic as we will show later on\). 
+In addition, it has a context from which it extracts information to execute itself. 
+In its basic form, there is not much more than that.
+
+Let us have a look at examples. 
+We will define some commands for the ContactBook application and illustrate how they can be turned into 
+menu and menubar.
+
+
+Note that we will present how Commander supports Spec menu and menubar creations.
+However such functionalities are not in the core of Commander.
+We show them because first, this is important to illustrate how to build user interface elements with Commander but also 
+because such functionalities show that Commander can be extended in a way that end-users do not have to feel 
+they are using special extensions.
+We will come back to such a point in the last chapter of this book to show potential extenders of Commander that they can get inspiration from the Spec extensions.
+
+
+### Adding some convenience methods
+
+
+For convenience reasons, we define a common superclass to all the commands of the contact book application named `EgContactBookCommand`.
+
+```
+CmCommand << #EgContactBookCommand
+    package: 'EgContactBook'
+```
+
+
+
+We define a simple helper method to make the code more readable
+```
+EgContactBookCommand >> contactBookPresenter
+    ^ self context
+```
+
+
+For the same reason, we define another helper to access the contact book and the selected item.
+```
+EgContactBookCommand >> contactBook
+    ^ self contactBookPresenter contactBook
+```
+
+
+```
+EgContactBookCommand >> selectedContact
+    ^ self contactBookPresenter selectedContact
+```
+
+
+Using such helper methods we defined the method `hasSelectContract` as follows:
+
+```
+EgContactBookCommand >> hasSelectedContact
+    ^ self contactBookPresenter isContactSelected
+```
+
+
+#### Adding the add contact command
+
+
+We define a subclass to define the add a contact command. 
+```
+EgContactBookCommand << #EgAddContactCommand
+    package: 'EgContactBook'
+```
+
+
+```
+CmAddContactCommand >> initialize
+    super initialize.
+    self
+        basicName: 'New contact'; 
+        basicDescription: 'Creates a new contact and add it to the contact book.'
+```
+
+
+```
+CmAddContactCommand >> execute
+    
+    | contact |
+    contact := self contactBookPresenter newContact.
+    self hasSelectedContact
+        ifTrue: [ self contactBook addContact: contact after: self selectedContact ]
+        ifFalse: [ self contactBook addContact: contact ].
+        
+    self contactBookPresenter updateView
+```
+
+
+We should define the method `updateView` to refresh the contents of the table.
+
+```
+EgContactBookPresenter >> updateView
+    table items: contactBook contacts
+```
+
+
+Now in the inspect pane, we can simply execute the command as follows:
+
+```
+(EgAddContactCommand new context: self) execute
+```
+
+
+Executing the command should ask you to give a name and a phone number
+and will get added to the list.
+
+We can also execute the following snippet.
+
+```
+| presenter cmd |
+presenter := EgContactBookPresenter on: EgContactBook coworkers.
+cmd := EgAddContactCommand new context: presenter.
+cmd execute
+```
+
+
+### Adding the remove contact command
+
+
+We define now another command to remove a command. 
+This example is interesting because it does not involve any UI interaction.
+It shows that a command is not necessarily linked to UI interaction.
+
+```
+EgContactBookCommand << #EgRemoveContactCommand
+    package: 'EgContactBook'
+```
+
+
+```
+EgRemoveContactCommand >> initialize
+    super initialize.
+    self
+        name: 'Remove'; 
+        description: 'Removes the selected contact from the contact book.'
+```
+
+
+This command definition illustrates how we can control when a command should or not be executed. The method `canBeRun` allows one to specify such a condition.
+
+```
+EgRemoveContactCommand >> canBeExecuted
+    ^ self context isContactSelected
+```
+
+
+The method `execute` is straightforward.
+```
+EgRemoveContactCommand >> execute
+    self contactBook removeContact: self selectedContact.
+    self contactBookPresenter updateView
+```
+
+
+The following test validates the correct execution of the command.
+
+```
+EgContactCommandTest >> testRemoveContact
+
+    self assert: presenter contactBook size equals: 3.
+    presenter table selectIndex: 1.
+    (EgRemoveContactCommand new context: presenter) execute.
+    self assert: presenter contactBook size equals: 2
+```
+
+
+
+### Turning commands into menu items
+
+Now that we have our commands we would like to reuse them and turn them into menus. 
+In Spec, commands that are transformed into menu items are structured into a tree of command instances. 
+The class method `buildCommandsGroupWith:forRoot:` of `SpPresenter` is a hook to let presenters define the root of the command instance tree.
+
+A command is transformed into a command for Spec using the message `forSpec`.
+We will show later that we can add UI-specific information to a command such as an icon and a shortcut.
+
+The method `buildCommandsGroupWith:forRoot:` registers commands to which the presenter instance is passed as context. 
+Note that here we just add plain commands, but we can also create groups. 
+This is also in this method that we will specify a toolbar.
+
+```
+EgContactBookPresenter class >> 
+    buildCommandsGroupWith: presenter 
+    forRoot: rootCommandGroup
+    
+    rootCommandGroup 
+        register: (EgAddContactCommand forSpec context: presenter);
+        register: (EgRemoveContactCommand forSpec context: presenter)
+```
+
+
+We now have to attach the root of the command tree to the table. 
+This is what we do with the new line in the `initializePresenters` method. 
+Notice that we have full control and as we will show we could select a subpart of the tree \(using the message `/`\) and define it as root for a given component.
+
+
+```
+EgContactBookPresenter >> initializePresenters
+    table := self newTable.
+    table 
+        addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);
+        addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).
+    table contextMenu: [ self rootCommandsGroup beRoot asMenuPresenter ].
+    table items: contactBook contacts.
+```
+
+
+Reopening the interface `(EgContactBookPresenter on: EgContactBook coworkers) openWithSpec` you should see the menu items as shown in Figure *@withmenu@*.
+As we will show later we could even replace a menu item with another one, changing its name, or icon in place.
+
+![With two menu items with groups.](figures/withMenus.png width=60&label=withmenu)
+
+### Introducing groups
+
+
+Commands can be managed in groups and such groups can be turned into corresponding menu item sections.
+The key hook method is the class method named `buildCommandsGroupWith: presenterInstance forRoot:`.
+
+
+Here we give an example of such grouping. 
+Note that the message `asSpecGroup` sent to a group.
+We create two methods creating each a simple group one for adding and one for removing contracts.
+
+```
+EgContactBookPresenter class >> buildAddingGroupWith: presenter
+    ^ (CmCommandGroup named: 'Adding') asSpecGroup
+        description: 'Commands related to contact addition.';
+        register: (EgAddContactCommand forSpec context: presenter);
+        beDisplayedAsGroup;
+        yourself
+```
+
+
+```
+EgContactBookPresenter class >> buildRemovingGroupWith: presenter
+    ^ (CmCommandGroup named: 'Removing') asSpecGroup
+        description: 'Commands related to contact removal.';
+        register: (EgRemoveContactCommand forSpec context: presenter);
+        beDisplayedAsGroup;
+        yourself
+```
+
+
+We group the previously defined groups together under the contextual menu for example. 
+
+```
+EgContactBookPresenter class >> buildContextualMenuGroupWith: presenter
+    ^ (CmCommandGroup named: 'Context Menu') asSpecGroup
+        register: (self buildAddingGroupWith: presenter);
+        register: (self buildRemovingGroupWith: presenter);
+        yourself
+```
+
+
+Finally, we revisit the hook `buildCommandsGroupWith:forRoot:` to register the last group to the root command group.
+
+```
+EgContactBookPresenter class >> 
+    buildCommandsGroupWith: presenter 
+    forRoot: rootCommandGroup
+    
+    rootCommandGroup
+        register: (self buildContextualMenuGroupWith: presenter)
+```
+
+
+Reopening the interface `(EgContactBookPresenter on: EgContactBook coworkers) openWithSpec` you should see the menu items inside a `'Context Menu'` as shown in Figure *@withmenuContext@*.
+
+![With a context menu.](figures/withmenuContext.png width=60&label=withmenuContext)
+
+To show you that we can also select a part of the command tree we select the `'Context Menu'` group and declare it as the root of the table menu.
+In such case, you will not see the `'Context Menu'` anymore. 
+
+```
+EgContactBookPresenter >> initializePresenters
+
+    table := self newTable.
+    table 
+        addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);
+        addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).
+    
+    table contextMenu: [ (self rootCommandsGroup / 'Context Menu') beRoot asMenuPresenter ].
+    table items: contactBook contacts
+```
+
+
+### Extending menus
+
+
+Building a menu is nice, but sometimes we need to add a menu to an existing one. 
+Commander supports this via a dedicated pragma, called `<extensionCommands>` that identifies extensions. 
+
+as we show it now. 
+
+
+Imagine that we have new functionality that we want to add to the contact book and that this behavior is packaged in another package, here, `EgContactBook-Extensions`.
+First, we will define a new command and second, we will show how we can extend the existing menu to add a new menu item. 
+
+```
+EgContactBookCommand << #EgChangePhoneCommand
+    slots: { #newPhone};
+    package: 'EgContactBook-Extensions'
+```
+
+
+```
+EgChangePhoneCommand >> newPhone: anObject
+    newPhone := anObject
+```
+
+
+```
+EgChangePhoneCommand >> newPhone
+    ^ newPhone 
+```
+
+
+```
+EgChangePhoneCommand >> initialize
+    super initialize.
+    self
+        name: 'Change phone';
+        description: 'Change the phone number of the contact.'
+```
+
+
+```
+EgChangePhoneCommand >> execute
+    self selectedContact phone: self contactBookPresenter newPhone.
+    self contactBookPresenter updateView
+```
+
+
+We add `ContactBookPresenter` with the method `newPhone` the presenter to support the definition of the new phone number. 
+The point here is not that this is method is or not packaged with the new command.
+
+```
+EgContactBookPresenter >> newPhone
+    | phone |
+    phone := self 
+        request: 'New phone for the contact'
+        initialAnswer: self selectedContact phone 
+        title: 'Set new phone for contact'.
+    (phone matchesRegex: '\d\d\d\s\d\d\d')
+        ifFalse: [ 
+            SpInvalidUserInput signal: 'The phone number is not well formatted. 
+Should match "\d\d\d\s\d\d\d"' ].
+    ^ phone
+```
+
+
+The last missing piece is the declaration of the extension.
+This one is done using the pragma `<extensionCommands>` on the class side of the presenter class as follows:
+
+Here we see that using slash \(` / `\), we can select the group in which we want to add the item.
+
+```
+EgContactBookPresenter class >> 
+    changePhoneCommandWith: presenter 
+    forRootGroup: aRootCommandsGroup
+    
+    <extensionCommands>
+    
+    (aRootCommandsGroup / 'Context Menu')
+        register: (EgChangePhoneCommand forSpec context: presenter)
+```
+
+
+
+![With menu extension.](figures/withmenuExtension.png width=60&label=withmenuExtension)
+
+
+### Managing icons and shortcuts
+
+
+By default a command does not know about Spec-specific behavior, this is because a command does not have to be linked to UI.
+Now obviously you want to have icons and shortcut bindings when you are designing an interactive application.
+
+Commander supports the addition of icons and shortcut keys to commands.
+Let us see how it works from a user perspective. 
+The framework offers two methods to set icon and shortcut key: `iconName:` and `shortcutKey:`.
+We should specialize the method `aSpecCommand` as follows: 
+
+```
+EgRemoveContactCommand >> asSpecCommand
+    ^ super asSpecCommand
+        iconName: #removeIcon;
+        shortcutKey: $x meta;
+        yourself
+```
+
+
+
+```
+EgRemoveContactCommand >> asSpecCommand
+    ^ super asSpecCommand
+        shortcutKey: $n meta;
+        iconName: #changeAdd;
+        yourself
+```
+
+
+Note that the commands are created using the message `forSpec` and this is this message that takes care of the calling of `asSpecCommand`.
+
+### Enabling shortcuts
+
+
+To the time of this chapter writing, Commander management of shortcuts has not been pushed to Spec to avoid dependency on Commander. 
+It is then the responsibility of your presenter to manage shortcuts as shown in the following method.
+We ask the command group to install the shortcut handler in the window.
+
+```
+EgContactBookPresenter >> initializeWindow: aWindowPresenter
+    
+    super initializeWindow: aWindowPresenter.
+    self rootCommandsGroup installShortcutsIn: aWindowPresenter
+```
+
+
+### In-place customisation
+
+
+Commander supports also the reuse and in-place customisation of commands.
+It means that the instance representing a command can be modified on the spot: for example, its name or description can be adapted to the exact 
+use context.
+Here is an example that shows that we adapt twice the same command.
+
+Let us define a really simple and generic command that will simply inspect the object. 
+
+```
+EgContactBookCommand << #EgInspectCommand
+    package: 'EgContactBook-Extensions'
+```
+
+
+```
+EgInspectCommand >> initialize
+    super initialize.
+    self
+        name: 'Inspect';
+        description: 'Inspect the context of this command.'
+```
+
+
+```
+EgInspectCommand >> execute
+    self context inspect
+```
+
+
+Using a block the context is computed at the moment the command is executed and the name and description can be adapted for its specific usage as shown in Figure *@inPlaceCustomisation@*.
+
+```
+EgContactBookPresenter class >>    
+    extraCommandsWith: presenter 
+    forRootGroup: aRootCommandsGroup
+    
+    <extensionCommands>
+    
+    aRootCommandsGroup / 'Context Menu'
+        register:
+            ((CmCommandGroup named: 'Extra') asSpecGroup
+                description: 'Extra commands to help during development.';
+                register:
+                    ((EgInspectCommand forSpec context: [ presenter selectedContact ])
+                        name: 'Inspect contact';
+                        description: 'Open an inspector on the selected contact.';
+                        iconName: #smallFind;
+                        yourself);
+                register:
+                    ((EgInspectCommand forSpec context: [ presenter contactBook ])
+                        name: 'Inspect contact book';
+                        description: 'Open an inspector on the contact book.';
+                        yourself);
+                yourself)
+```
+
+
+![With menu extension.](figures/inPlaceCustomisation.png width=95&label=inPlaceCustomisation)
+
+### Managing a menu bar
+
+
+Commander supports also menu bar creation.
+The logic is the same as for contextual menus: we define a group and register it under a given and we specify to the presenter to use this group 
+as a menubar.
+
+Imagine that we have a new command to print the contact.
+
+```
+EgContactBookCommand << #EgPrintContactCommand
+    package: 'EgContactBook'
+```
+
+
+```
+EgPrintContactCommand >> initialize
+    super initialize.
+    self
+        name: 'Print';
+        description: 'Print the contact book in Transcript.'    
+```
+
+
+```
+EgPrintContactCommand >> execute
+
+    Transcript open.
+    self contactBook contacts do: [ :contact | self traceCr: contact name , ' - ' , contact name ]
+```
+
+
+
+We create a simple group that we call 'MenuBar' \(but it could be called anything\).
+
+```
+EgContactBookPresenter class >> buildMenuBarGroupWith: presenter
+    ^ (CmCommandGroup named: 'MenuBar') asSpecGroup
+        register: (EgPrintContactCommand forSpec context: presenter);
+        yourself
+```
+
+
+We modify the root to get the menu bar group in addition to the previous ones. 
+```
+EgContactBookPresenter class >> 
+    buildCommandsGroupWith: presenter 
+    forRoot: rootCommandGroup
+    
+    rootCommandGroup
+        register: (self buildMenuBarGroupWith: presenter);
+        register: (self buildContextualMenuGroupWith: presenter)
+```
+
+
+And we hook it into the widget as the last line of the `initializePresenters` method. 
+Notice the use of the message `asMenuBarPresenter` and the addition of a new instance variable called `menuBar`.
+
+```
+EgContactBookPresenter >> initializePresenters
+    table := self newTable.
+    table 
+        addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);
+        addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).
+    table contextMenu: [ (self rootCommandsGroup / 'Context Menu') beRoot asMenuPresenter ].
+    table items: contactBook contents.
+    menuBar := (self rootCommandsGroup / 'MenuBar') asMenuBarPresenter.
+```
+
+
+Finally, to get the menu bar you should declare it in the layout.
+
+```
+EgContactBookPresenter class >> defaultSpec
+
+    ^ SpBoxLayout newVertical
+            add: #menuBar
+            withConstraints: [ :constraints | constraints height: self toolbarHeight ];
+            add: #table; 
+            yourself
+```
+
+
+![With menubar.](figures/withmenubar.png width=60&label=inPlaceCustomisation)
+
+
+### Conclusion
+
+In this chapter, we saw how you can define a simple command and execute it in a given context. 
+We show how you can turn a command into a menu item in Spec20 by sending the message `forSpec`. 
+You learned how we can reuse and customize commands. 
+We presented groups of commands as a way to structure menus and menubars. 


### PR DESCRIPTION
This is the first-pass review of chapter 3 on "Most of Spec in one example".

Later I will submit another PR to fix and improve the examples and to address the questions in the chapter. Things on my mind are:
* Shouldn't the section "An application manages icons" have an example?
* Figure "Better window" has a button "Save", but it has to be "Save Film".
* Figure "Better window" should show a window that is less high than the window in figure "Using the non homogeneous grid layout" because now it is unclear that the smaller initial intent has been applied. Actually, the figure should show a window, not a dialog because the dialog is introduced afterwards in section "Customizing the modal dialog".
* There is a typo in the name field in figure "Customizing the dialog window". It reads "Chlinder". It should be "Chindler". I would write "1998" instead of "98" in the field "Year".
* The same typo is present in figure "Film list gets refreshed" and figure "Embedding the film description in the list: selecting a list item populates the detailed visual component".
* In section "Adding more tests" probably there is a mistake in the last assert, which asserts on "name", while name has not been bound to another object since the previous assert.
* In section "Using transmissions" there is a question from Stéphane. I think this section is too short for such an important feature.
* Section "Styling the application" states that stylesheets are different for GTK and Morphic. That is sad because Spec is intended to be backend-independent. This cannot be fixed in the book. It is just an observation.
* In the same section, there is a question from Stéphane that has to be addressed.