### PR TITLE
Improvements to chapter 8 (Reuse and composition at work)

### DIFF
--- a/Chapters/CaseStudyTwo/CaseStudyTwo.md
+++ b/Chapters/CaseStudyTwo/CaseStudyTwo.md
@@ -394,7 +394,7 @@ together and this is not visually good.
 - finally, the layout itself was added with `expand` set to `false` to prevent the button from taking half the size vertically. 
 - `add:expand: false` The `expand` property indicates the layout will not resize the button to take the whole available space.
 
-**NOTE:** The expand property is important to place your elements correctly, but it does not do magic: when this property is set the layout will take the default size of the added presenter to determine its place. But it may happen that the defaults are not good and there are different things you can do (like define your own style), but this will not covered in this tutorial (we will work on that later).  
+**Note.** The expand property is important to place your elements correctly, but it does not do magic: when this property is set the layout will take the default size of the added presenter to determine its place. But it may happen that the defaults are not good and there are different things you can do (like define your own style), but this will not covered in this tutorial (we will work on that later).  
 
 Finally, we create the method `addTask`.
 
@@ -523,4 +523,3 @@ In this tutorial, we show that Spec presenters are responsible for defining:
 - their layouts (how such components are displayed)
 - how such components interact
 - and the logic of the application (here we just added and deleted elements from a list).
-

--- a/Chapters/ManagingWindow/ManagingWindow.md
+++ b/Chapters/ManagingWindow/ManagingWindow.md
@@ -297,7 +297,7 @@ WindowExamplePresenter >> windowIcon
 ```
 
 
-**NOTE:** Changing the `windowIcon` method will affect all open windows, as the taskbar is periodically refreshed. This refreshing is also why `windowIcon:` can be sent before or after the window has been opened.
+**Note.** Changing the `windowIcon` method will affect all open windows, as the taskbar is periodically refreshed. This refreshing is also why `windowIcon:` can be sent before or after the window has been opened.
 
 ### Setting the about text
 

--- a/Chapters/Reuse/Reuse.md
+++ b/Chapters/Reuse/Reuse.md
@@ -1,14 +1,12 @@
 ## Reuse and composition at work
 @cha_reuse
 
-status: Currently working on it. 
+status: Currently working on it.
 status: spellchecked
 
-A key design goal of Spec is to enable the seamless reuse of user interfaces. 
-The reason for this is that it results in a significant productivity boost when creating user interfaces.
+A key design goal of Spec is to enable the seamless reuse of user interfaces. The reason for this is that it results in a significant productivity boost when creating user interfaces.
 
-This focus on reuse was actually already visible in the previous chapters, where we have seen that basic widgets can be used as if they were a complete user interface. In this section we focus on the reuse and composition of presenters, showing that it basically comes for free.
-The only requirement when building a UI is to consider how the user interface should be parameterized when it is being reused.
+This focus on reuse was actually already visible in the previous chapters, where we have seen that basic widgets can be used as if they were a complete user interface. In this section we focus on the reuse and composition of presenters, showing that it basically comes for free. The only requirement when building a UI is to consider how the user interface should be parameterized when it is being reused.
 
 Said differently, in this chapter, you will learn how we can build a new UI by reusing already defined elements.
 
@@ -26,16 +24,11 @@ To show how Spec enables the composition and reuse of user interfaces, in this c
 
 
 
-
-
-
 ### Creating a basic UI to be reused as a widget
 @sec_WidgetClassList
 
 The first custom UI we build should display a list of all subclasses of
- the class `AbstractWidgetPresenter`.
-This UI will later be reused as a widget for a more complete UI. 
-The code is as follows (we do not include code for accessors):
+ the class `AbstractWidgetPresenter`. This UI will later be reused as a widget for a more complete UI. The code is as follows (we do not include code for accessors):
 
 First, we create a subclass of `SpPresenter` with one instance variable `list` which will hold an instance of `SpListModel`.
 
@@ -50,6 +43,7 @@ In the method `initializePresenters`, we create the list and populate it with th
 
 ```
 WidgetClassListPresenter >> initializePresenters
+
     list := self newList.
     list items: (AbstractWidgetModel allSubclasses
                      sorted: [:a :b | a name < b name ]).
@@ -60,6 +54,7 @@ We also add a title for the window.
 
 ```
 WidgetClassListPresenter >> initializeWindow: aWindowPresenter
+
     aWindowPresenter title: 'Widgets'
 ```
 
@@ -67,12 +62,13 @@ The layout contains only the list:
 
 ```
 WidgetClassListPresenter >> defaultLayout
-    ^ SpBoxLayout newLeftToRight 
+
+    ^ SpBoxLayout newLeftToRight
         add: #list;
         yourself
 ```
 
-Doing `WidgetClassListPresenter new open`, you should obtain UI shown in Figure *@fig_WidgetClassList@*.
+Doing `WidgetClassListPresenter new open`, you should obtain the UI shown in Figure *@fig_WidgetClassList@*.
 
 ![WidgetClassListPresenter open.](figures/WidgetClassList.png width=50&label=fig_WidgetClassList)
 
@@ -93,10 +89,7 @@ Now, whoever reuses this widget can parameterize it with a block that will be ex
 ### Combining two basic presenters into a reusable UI
 @sec_protocollist
 
-The UI we build now will show a list of all methods of a given protocol, and it combines two widgets: a list and a label. 
-Considering reuse, there is no difference from the previous UI. 
-This is because the reuse of a UI as a widget is **not impacted at all** by the number of widgets it contains (nor by their position). 
-Large and complex UIs are reused in the same way as simple widgets.
+The UI we build now will show a list of all methods of a given protocol, and it combines two widgets: a list and a label. Considering reuse, there is no difference from the previous UI. This is because the reuse of a UI as a widget is **not impacted at all** by the number of widgets it contains (nor by their position). Large and complex UIs are reused in the same way as simple widgets.
 
 ```
 SpPresenter << #ProtocolMethodListPresenter
@@ -106,15 +99,14 @@ SpPresenter << #ProtocolMethodListPresenter
 ```
 
 
-The `initializePresenters` method for this UI is quite straightforward. 
-We specify the default label text as 'protocol', which will be changed when the widget is reused. 
-We also give this UI a title.
+The `initializePresenters` method for this UI is quite straightforward. We specify the default label text as 'protocol', which will be changed when the widget is reused. We also give this UI a title.
 
 ```
 ProtocolMethodListPresenter >> initializePresenters
+
     methods := self newList.
     methods displayBlock: [ :m | m selector ].
-    label :=  self newLabel.
+    label := self newLabel.
     label label: 'Protocol'.
     self focusOrder add: methods.
 ```
@@ -125,6 +117,7 @@ define the method `initializeWindow:`.
 
 ```
 ProtocolMethodListPresenter >> initializeWindow: aWindowPresenter
+
     aWindowPresenter title: 'Protocol widget'
 ```
 
@@ -134,29 +127,29 @@ The layout code builds a column with the fixed-height label on top and the list 
 
 ```
 ProtocolMethodListPresenter >> defaultLayout
-    ^ SpBoxLayout newTopToBottom 
-            add: #label ;
-            add: #methods ;
+
+    ^ SpBoxLayout newTopToBottom
+            add: #label;
+            add: #methods;
             yourself
 ```
 
 
-This UI can be seen by executing `ProtocolMethodList new open`. 
-As shown in Figure *@figprotocollist@* the list is empty and the result not really nice. 
-This is normal since we did not set any items but we should also place better the elements.
+This UI can be seen by executing `ProtocolMethodList new open`. As shown in Figure *@figprotocollist@* the list is empty and the result not really nice. This is normal since we did not set any items but we should also place the elements better.
 
 ![ProtocolMethodListPresenter with unclear layout.](figures/ProtocolList.png width=50&label=figprotocollist)
 
 ```
 ProtocolMethodListPresenter >> defaultLayout
+
     ^ SpBoxLayout newVertical
-            add: #label  withConstraints: [:c | c expand: false];
-            add: #methods withConstraints: [:c | c fill];
+            add: #label expand: false;
+            add: #methods withConstraints: [ :constraints | constraints fill];
             yourself
 ```
 
 
-Now you should get a better look as shown in Figure *@figprotocollist2@*.
+Now you should get a better UI as shown in Figure *@figprotocollist2@*.
 
 
 ![ProtocolMethodListPresenter with nicer layout.](figures/ProtocolList2.png width=50&label=figprotocollist2)
@@ -165,48 +158,51 @@ Our protocol method list will need to be configured when it is used, for example
 
 ```
 ProtocolMethodListPresenter >> items: aCollection
+
     methods items: aCollection
 ```
 
 ```
 ProtocolMethodListPresenter >> label: aText
+
     label label: aText
 ```
 
 ```
 ProtocolMethodListPresenter >> resetSelection
+
     methods selection unselectAll
 ```
 
 
 ```
 ProtocolMethodListPresenter >> whenSelectionChangedDo: aBlock
+
     methods whenSelectionChangedDo: aBlock
 ```
 
 
-#### Note. 
-An alternative to adding these methods is simply to do nothing: since both the methods and the label are accessible through their accessors, a reuser of this widget may simply obtain them and configure them directly. These two alternatives reflect design decisions that we will discuss later in Section *@sec_public_API@*.
+**Note.** An alternative to adding these methods is simply to do nothing: since both the methods and the label are accessible through their accessors, a reuser of this widget may simply obtain them and configure them directly. These two alternatives reflect design decisions that we will discuss later in Section *@sec_public_API@*.
 
-### Inspecting live the widgets
+### Live inspection of the widgets
 
 Now we can check manually if the widget is working by doing:
 
 ```
-ProtocolMethodListPresenter new open ; inspect
+ProtocolMethodListPresenter new open; inspect
 ```
 
 
 Then in the inspector, we can use the newly created methods to pass a collection of methods:
 
 ```
-    self items: Point methods
+self items: Point methods
 ```
 
 
 ![Live coding your widgets (no it is not openWithSpec but open my friend but the background is supercool!).](figures/inspectingLive.png width=90&label=figinspectingLive)
 
-Now we can play and for example, decide to sort the items as follows: 
+Now we can play and for example, decide to sort the items as follows:
 
 ```
 self items: (Point methods sort: #selector ascending)
@@ -215,15 +211,13 @@ self items: (Point methods sort: #selector ascending)
 
 ### Writing tests
 
-When we start to feel the need to check manually what we have done, this is a sign that we should write a test instead. 
-So let us do that. 
-It is easy to write simple tests for widgets when we do not test popups. 
-So let us take advantage of that.
+When we start to feel the need to check manually what we have done, this is a sign that we should write a test instead. So let us do that. It is easy to write simple tests for widgets when we do not test popups. So let us take advantage of that.
 
 We add an accessor to access the method list.
 
 ```
 ProtocolMethodListPresenter >> methods
+
     ^ methods
 ```
 
@@ -247,8 +241,7 @@ ProtocolMethodListPresenterTest >> testItems
 ```
 
 
-We hope that we convinced you that writing simple UI tests is easy with Spec. 
-Do not miss this opportunity to control the complexity of your software. 
+We hope that we convinced you that writing simple UI tests is easy with Spec. Do not miss this opportunity to control the complexity of your software.
 
 
 ### Managing three widgets and their interactions
@@ -285,12 +278,12 @@ ProtocolViewerPresenter >> initializePresenters
 
 ```
 ProtocolViewerPresenter >> initializeWindow: aWindowPresenter
+
     aWindowPresenter title: 'Protocol viewer'
 ```
 
 
-To describe the interactions between the different widgets we define the `connectPresenters` method. It specifies that when a class is selected, the selections in the method lists are reset and both method lists are populated. 
-Additionally, when a method is selected in one method list, the selection in the other list is reset.
+To describe the interactions between the different widgets we define the `connectPresenters` method. It specifies that when a class is selected, the selections in the method lists are reset and both method lists are populated. Additionally, when a method is selected in one method list, the selection in the other list is reset.
 
 ```
 ProtocolViewerPresenter >> connectPresenters
@@ -301,8 +294,8 @@ ProtocolViewerPresenter >> connectPresenters
         events resetSelection.
         class := selection selectedItem.
         class
-            ifNil: [ 
-                api items: #(). 
+            ifNil: [
+                api items: #().
                 events items: #() ]
             ifNotNil: [
                 api items: (self methodsIn: class for: 'api').
@@ -317,6 +310,7 @@ ProtocolViewerPresenter >> connectPresenters
 
 ```
 ProtocolViewerPresenter >> methodsIn: class for: protocol
+
     ^ (class methodsInProtocol: protocol) sorted:
              [ :a :b | a selector < b selector ]
 ```
@@ -325,9 +319,10 @@ Lastly, the layout puts the sub-widgets in one column, with all sub-widgets taki
 
 ```
 ProtocolViewerPresenter >> defaultLayout
+
     ^ SpBoxLayout newTopToBottom
-        add: #models; 
-        add: #api; 
+        add: #models;
+        add: #api;
         add: #events;
         yourself
 ```
@@ -345,16 +340,17 @@ This user interface is functional, clicking on a class will show the methods of 
 
 
 Notice that you can change the layout as follows to get all the widgets in a row as shown in Figure *@figProtocolViewerHorizontal@*.
-We will show later that a presenter can have multiple layouts and that the programmer decide which one to use.
+We will show later that a presenter can have multiple layouts and that the programmer decides which one to use.
 
 
-We can do better. Let us define three methods as follows: 
+We can do better. Let us define two methods as follows:
 
 ```
 ProtocolViewerPresenter >> horizontalLayout
-    ^ SpBoxLayout newLeftToRight 
-        add: #models; 
-        add: #api; 
+
+    ^ SpBoxLayout newLeftToRight
+        add: #models;
+        add: #api;
         add: #events;
         yourself
 ```
@@ -362,9 +358,10 @@ ProtocolViewerPresenter >> horizontalLayout
 
 ```
 ProtocolViewerPresenter >> verticalLayout
-    ^ SpBoxLayout newTopToBottom 
-        add: #models; 
-        add: #api; 
+
+    ^ SpBoxLayout newTopToBottom
+        add: #models;
+        add: #api;
         add: #events;
         yourself
 ```
@@ -372,6 +369,7 @@ ProtocolViewerPresenter >> verticalLayout
 
 ```
 ProtocolViewerPresenter >> defaultLayout
+
     ^ self verticalLayout
 ```
 
@@ -379,6 +377,7 @@ Now we can decide to open the viewer with different layouts using the message `o
 
 ```
 ProtocolViewerPresenter class >> exampleHorizontal
+
     | inst |
     inst := self new.
     inst openWithLayout: inst horizontalLayout
@@ -391,20 +390,23 @@ ProtocolViewerPresenter class >> exampleHorizontal
 ### Enhancing our API
 
 
-Similar to the second user interface, when this UI is reused it will probably need to be configured. The relevant configuration here is what to do when a selection change happens in any of the three lists. We hence add the following three methods to the `api` protocol.
+Similar to the second user interface, when this UI is reused it will probably need to be configured. The relevant configuration here is what to do when a selection change happens in any of the three lists. Hence we add the following three methods to the `api` protocol.
 
 ```
 ProtocolViewerPresenter >> whenSelectionInAPIChanged: aBlock
+
     api whenSelectionChangedDo: aBlock
 ```
 
 ```
 ProtocolViewerPresenter >> whenSelectionInClassChanged: aBlock
+
     models whenSelectionChangedDo: aBlock
 ```
 
 ```
 ProtocolViewerPresenter >> whenSelectionInEventChanged: aBlock
+
     events whenSelectionChangedDo: aBlock
 ```
 
@@ -417,7 +419,7 @@ These methods add semantic information to the configuration API. They state that
 
 @sec_protocolbrowser
 
-Sometimes, when you want to reuse an existing UI as a widget, the layout of that UI is not appropriate to your needs. Spec allows you to nonetheless reuse such a UI by overriding the layout of its widgets, and we show this here.
+Sometimes, when you want to reuse an existing UI as a widget, the layout of that UI is not appropriate for your needs. Nonetheless Spec allows you to reuse such a UI by overriding the layout of its widgets, and we show this here.
 
 Our last user interface reuses the `ProtocolViewerPresenter` with a different layout and adds a text zone to edit the source code of the selected method.
 
@@ -430,6 +432,7 @@ SpPresenter << #ProtocolCodeBrowserPresenter
 
 ```
 ProtocolCodeBrowserPresenter >> initializePresenters
+
     text := self instantiate: SpCodePresenter.
     viewer := self instantiate: ProtocolViewerPresenter.
     text syntaxHighlight: true.
@@ -440,7 +443,7 @@ ProtocolCodeBrowserPresenter >> initializePresenters
 
 ```
 ProtocolCodeBrowserPresenter >>defaultLayout
-    
+
     ^ SpBoxLayout newTopToBottom
             add: (SpBoxLayout newHorizontal add: #viewer ; yourself);
             add: #text;
@@ -449,6 +452,7 @@ ProtocolCodeBrowserPresenter >>defaultLayout
 
 ```
 ProtocolCodeBrowserPresenter >> initializeWindow: aWindowPresenter
+
     aWindowPresenter title: 'Spec Protocol Browser'
 ```
 
@@ -466,13 +470,12 @@ ProtocolCodeBrowserPresenter >> connectPresenters
             ifNotNil: [ :item | text text: item sourceCode ] ]
 ```
 
-SHOULD Update 
+SHOULD Update
 
 ```
 initializePresenters
-    
+
     self instantiate: ProtocolViewer withLayout: ProtocolViewer horizontalLayout
-    
 ```
 
 
@@ -481,21 +484,21 @@ initializePresenters
 ```
 presenter := MyPresenter new.
 presenter openWithLayout: (SpBoxLayout newTopToBottom
-add: #models;
-add: #api;
-add: #events;
+    add: #models;
+    add: #api;
+    add: #events;
 yourself).
 ```
- 
+
 or you can do:
 
-````
+```
 presenter := MyPresenter new.
 presenter layout: (SpBoxLayout newTopToBottom
-add: #models;
-add: #api;
-add: #events;
-yourself).
+    add: #models;
+    add: #api;
+    add: #events;
+    yourself).
 presenter open.
 ```
 
@@ -514,38 +517,31 @@ ESTEBAN how I can do
 
 ````
 ProtocolCodeBrowserPresenter >> initializePresenters
+
     text := self instantiate: SpCodePresenter.
     viewer := self instantiate: ProtocolViewerPresenter.
     BUT WITH ANOTHER LAYOUT DEFINED ON PROTOCOLVIEWER PRESENTER
     self focusOrder
         add: viewer;
         add: text
-
 ```
 
 ### Considerations about a public configuration API
 
 @sec_public_API
 
-In this chapter, we have seen several definitions of methods in the public configuration API of the widget being built.
+In this chapter, we have seen several definitions of methods in the public configuration API of the presenter being built.
 The implementation of our configuration methods here is simply delegated to internal widgets, but a configuration can of course be more complex than that, depending on the internal logic of the UI.
 
-For methods that simply delegate to the internal widgets, the question is whether it makes sense to define these as methods in the `api` protocols at all.
-This fundamentally is a design decision to be made by the programmer.
-Not having such methods makes the implementation of the widget more lightweight but comes at the cost of a less clear intent and of breaking encapsulation.
+For methods that simply delegate to the internal widgets, the question is whether it makes sense to define these as methods in the `api` protocols at all. Fundamentally this is a design decision to be made by the programmer.
+Not having such methods makes the implementation of the presenter more lightweight but comes at the cost of a less clear intent and of breaking encapsulation.
 
 For the former cost, we have seen an example in the protocol method list of Section *@sec_protocollist@*.
-The presence of the three methods defined there communicates to the user that we care about what to do when a class, `api` or `api-events` list item has been changed.
-The same fundamentally also holds for the other examples in this chapter: each method in an `api` protocol communicates an intent to the reuser: this is how we expect that this widget will be configured.
-Without such declared methods, it is less clear to the reuser what can to be done to be able to effectively reuse this widget.
+The presence of the three methods defined there communicates to the user that we care about what to do when a class, `api` or `api-events` list item has been changed. Fundamentally the same also holds for the other examples in this chapter: each method in an `api` protocol communicates an intent to the reuser: this is how we expect that this presenter will be configured. Without such declared methods, it is less clear to the reuser what can be done to effectively reuse this presenter.
 
-For the latter cost, expecting reusers of the widget to directly send messages to internal objects (in instance variables) means breaking encapsulation.
-As a consequence, we are no longer free to change the internals of the UI, e.g., by renaming the instance variables to a better name or changing the kind of widget used.
-Such changes may break reusers of the widget and hence severely limit how we can evolve this widget in the future.
-In the end, it is safer to define a public API and ensure in future versions of the widget that the functionality of this API remains the same.
+For the latter cost, expecting reusers of the widget to directly send messages to internal objects (in instance variables) means breaking encapsulation. As a consequence, we are no longer free to change the internals of the UI, e.g., by renaming the instance variables to a better name or changing the kind of widget used. Such changes may break reusers of the presenter and hence severely limit how we can evolve this presenter in the future. In the end, it is safer to define a public API and ensure in future versions of the presenter that the functionality of this API remains the same.
 
-So in the end it is important to consider future reusers of your UI and the future evolution of your UI.
-You need to make a tradeoff of writing extra methods versus possibly making reuse of the UI harder as well as possibly making future evolution of the UI harder.
+So in the end it is important to consider future reusers of your UI and the future evolution of your UI. You need to make a tradeoff between writing extra methods and possibly making reuse of the UI harder as well as possibly making future evolution of the UI harder.
 
 ### New versus old patterns
 
@@ -570,9 +566,7 @@ connectPresenters
         method ifNotNil: [ api resetSelection ] ].
 ```
 
-In Spec2 list presenters and friends are exposing a different one exposing the selection of the list itself. 
-The design rationale is that a selection is a complex object (multi selection...).
-So we have 
+In Spec2 list presenters and friends are exposing a different one exposing the selection of the list itself. The design rationale is that a selection is a complex object (multi selection...). So we have
 
 ```
     api whenSelectionChangedDo: [ :selection |
@@ -581,18 +575,17 @@ So we have
         selection selectedItem ifNotNil: [ api resetSelection ] ].
 ```
 
-Now the question for your presenter definers is what is the API that you should expose to your users. 
-We would say that it does not matter because exposing a API similar to the one of Spec1 is possible as shown below. 
+Now the question for your presenters is what is the API that you should expose to your users. We would say that it does not matter because exposing a API similar to the one of Spec1 is possible as shown below.
 
 ```
 whenSelectedItemChangedDo: aBlock
     methods whenSelectionChangedDo: [ :selection |
-        selection selectedItem ifNotNil: [ :i | aBlock value: i ] ]
+        selection selectedItem ifNotNil: [ :item | aBlock value: item ] ]
 ```
 
 
 Now we suggest using the Spec20 way because it will give your presenters consistency with the core presenters of Spec
-and it will make them easier to collaborate. 
+and it will make them easier to collaborate.
 
 
 ### Conclusion

--- a/guidelines.txt
+++ b/guidelines.txt
@@ -4,8 +4,10 @@ Here are some guidelines about writing style and spelling that resulted from dis
 * Write "subpresenter", not "sub-presenter".
 * Methods without comment have an empty line after the method selector.
 * Methods do not have a period on the last line.
+* Do not put a space before a semicolon in a cascaded message.
 * Write "Pharo image", not "Pharo Image.
 * Do not use protocol references because they are not useful and may change.
 * Write "Section 6.1", not "section 6.1".
 * Write "Figure 6-2", not "figure 6-2".
 * Do not use a prefix "Sp" for example class names because the prefix is reserved for Spec classes.
+* Start a note with "**Note.**".


### PR DESCRIPTION
This is the first-pass review of chapter 8 "Reuse and composition at work".

There are still issues to tackle in future PRs:
* I think adding numbered labels to the different parts in the first figure would be helpful as a reference for the reader.
* The caption of Figure 8-5 reads: "Live coding your widgets (no it is not openWithSpec but open my friend but the background is supercool!". I understand the super coolness of the photo with the lighthouse in the background, but the code in the photo is wrong and the caption is not very professional. I think we should replace the figure and adapt the caption.
* In section 8.7 "Managing three widgets and their interactions", messages like add: #symbolHere are used, but I think that API had not been explained before.
* In section 8.10 "Changing the layout of a reused widget", the code just above "SHOULD Update" does not handle the case when there is no selection. Shouldn't we add that? Or does that complicate the example?
* Fix "SHOULD Update" and fix "ESTEBAN how can I do" in section 8.11 "Changing layouts".
* In section 8.11 "Changing layouts", there is a message "layoutAlternative1", but the method is not defined.
* In general, we should decide to use "widget" or "presenter". In this PR, I changed some "widget" to "presenter", but not all. Will we use them interchangeably, or is it better to use "presenter" all the way?