### PR TITLE
Improvements to chapter 14 (Styling Applications)

### DIFF
--- a/Chapters/Style/Style.md
+++ b/Chapters/Style/Style.md
@@ -3,7 +3,7 @@
 
 status: spellchecked
 
-In this chapter, we will see how to use custom styles in Spec applications. We will start to present styles and then build a little editor like the one displayed hereafter.
+In this chapter, we will describe how to use custom styles in Spec applications. First we present styles and then we will build a little editor like the one displayed hereafter.
 
 We will show that an application in Spec manages styles and lets you adapt the look of a presenter as shown in Figure *@style1@*.
 
@@ -13,47 +13,45 @@ We give some basis before showing how to effectively use styles to enhance the l
 
 ### How do styles work?
 
-
-
 Styles in Spec work like CSS. They are style sheets in which the properties for presenting a presenter are defined. Properties such as colors, width, height, font, and others.
 As a general principle, it is better to use styles instead of fixed constraints, because your application will be more responsive.
 
 For example, you want a button to have a specific width and height.
-You can do it using constraints with the method add:withConstraints: or using styles. In both cases, the result will be as shown in Figure *@style2@*:
+You can do it using constraints with the method `add:withConstraints:` or using styles. In both cases, the result will be as shown in Figure *@style2@*:
 
-![Untitled window.](figures/style2.png width=50&label=style2)
+![A window with a button.](figures/style2.png width=50&label=style2)
 
-But, if you change the size of the fonts of the Pharo image using Settings/Appearance/Standard Fonts/Huge, using fixed constraints, you will obtain the following result shown in Figure *@@*.
+But, if you change the size of the fonts of the Pharo image using Settings/Appearance/Standard Fonts/Huge, using fixed constraints, you will obtain the following result shown in Figure *@style3@*.
 You will for example not be able to see the icons because the size is not recomputed correctly.
 
-![Badly scaled untitled window.](figures/style3.png width=50&label=style3)
+![Badly scaled window.](figures/style3.png width=50&label=style3)
 
-While using styles, the size of the button will also scale as shown by Figure *@style4@*.
+When using styles, the size of the button will also scale as shown in Figure *@style4@*.
 
-![Nicely scaled untitled window.](figures/style4.png width=50&label=style4)
+![Nicely scaled window.](figures/style4.png width=50&label=style4)
 
 
-### About stylesheet
+### About stylesheets
 
-Spec first collects the style for the presenter, then collects style for its
- sub-components. 'application' is the default root level, there is no
-'application' adapter.
+Spec first collects the style for the presenter, then collects the styles for its
+ subcomponents. 'application' is the default root level.
 
-A defined stylesheet has to always have a root element, and this root element
-needs to be called `'.application'`.
+A defined stylesheet always has a root element, and this root element
+has to be called `'.application'`.
 
-So each style follows a cascading style, starting from `.application` like
+Each style follows a cascading style, starting from `.application` like
 ```
 .application.label.header
 .application.link
 .application.checkBox
 ```
 
-There are two ways to express stylesheets: one for Morphic expressed using an extended version of STON and CSS for Gtk.
+There are two ways to express stylesheets: one for Morphic expressed using an extended version of STON, and CSS for Gtk.
 
 ### STON notation
 
-Morphic styles can be declared using the STON notation.
+Morphic styles can be declared using STON. STON is a textual object notation. It is described in a dedicated chapter in the _Enterprise Pharo_ book available at [http://books.pharo.org](http://books.pharo.org).
+
 Each style element can use specific properties defined by associated classes:
 
 - Geometry: `SpStyleGeometry`
@@ -71,7 +69,7 @@ Container { #borderColor: Color { #rgb: 0, #alpha: 0 }, #borderWidth: 2, #paddin
 ```
 
 You can define your style globally, and to your specific presenter, with the `addStyle:`
-message: for example `addStyle: 'section'`. 
+message: for example `addStyle: 'section'`.
 
 This message is specific to the `SpAbstractMorphicAdapter` backend.
 Here are two examples of stylesheets.
@@ -97,13 +95,13 @@ styleSheet
   .dim [
    Draw { #color : Color{ #rgb: 708480675 } } ]
  ],
- .link [  
+ .link [
   Geometry { #hResizing: true } ],
- .button [  
+ .button [
   Geometry { #width: 100 },
   .small [
      Geometry { #width: 26 } ] ],
- .checkBox [  
+ .checkBox [
   Geometry { #hResizing: true } ],
  .radioButton [
   Geometry { #hResizing: true } ],
@@ -113,7 +111,7 @@ styleSheet
   Geometry { #width: 150, #hResizing: true, #vResizing: true } ],
  .slider [
   Geometry { #width: 150, #hResizing: true } ],
- .actionBar [  
+ .actionBar [
   Container {
    #borderColor: Color { #rgb: 0, #alpha: 0 },
    #borderWidth: 2,
@@ -121,14 +119,14 @@ styleSheet
   Geometry { #width: 150, #height: 29, #hResizing: true, #vResizing: false } ],
  .menuBar [
   Geometry { #width: 150, #hResizing: true } ],
- .actionButton [  
+ .actionButton [
   Geometry { #width: 60, #hResizing: false },
   .showIcon [ Geometry { #width: 25 } ]  ],
  .toolBar [
   Geometry { #hResizing: true },
   .icons [
    Geometry { #height: 30 } ],
-  .iconsAndLabel [  
+  .iconsAndLabel [
    Geometry { #height: 45 } ] ],
  .text [
   Geometry { #height: 0 } ],
@@ -165,12 +163,9 @@ styleSheet
 
 ### Anatomy of a style
 
-The styles in Spec format are similar to CSS. 
-Stylesheets are written using STON as a format.
-STON, this  textual object notation is described in a dedicated chapter in the _Enterprise Pharo_ book available at [http://books.pharo.org](http://books.pharo.org).
-We need to write the styles as a string and then parse it as a STON file.
+The styles in Spec format are similar to CSS. We have to write the styles as a string and then parse it as a STON file.
 
-Here is an example that we will explain step by step below.
+Here is an example that we will explain step by step.
 
 ```
 '.application [
@@ -178,15 +173,12 @@ Here is an example that we will explain step by step below.
     .lightBlue [ Draw { #color: #lightBlue } ] ]'
 ```
 
-    
-We will go by steps.
-
 `SpPropertyStyle` has 5 subclasses: `SpContainerStyle`, `SpDrawStyle`, `SpFontStyle`, `SpTextStyle`, and `SpGeometryStyle`. These subclasses define the 5 types of properties that exist. On the class side, the method `stonName` indicates the name that we must put in the STON file.
 
 !!todo stonName above is unclear
 
 - `SpDrawStyle` modifies the properties related to the drawing of the presenter, such as the color and the background color.
-- `SpFontStyle` manipulates all related to fonts.
+- `SpFontStyle` manipulates properties related to fonts.
 - `SpGeometryStyle` is for sizes, like width, height, minimum height, etc.
 - `SpContainerStyle` is for the alignment of the presenters, usually with property is changed on the main presenter, which is the one that contains and arranges the other ones.
 - `SpTextStyle` controls the properties of the `SpTextInputFieldPresenter`.
@@ -206,7 +198,7 @@ Now we have two styles: lightGreen and lightBlue that can be applied to any pres
 ### Environmental variables
 
 
-We can also use environmental variables to get the values of the predefined colors of the current theme, or the fonts. For example, we can create two styles for changing the fonts of the letters of a presenter:
+We can also use environmental variables to get the values of the predefined colors and fonts of the current theme. For example, we can create two styles for changing the fonts of the text of a presenter:
 
 ```
 '.application [
@@ -216,8 +208,7 @@ We can also use environmental variables to get the values of the predefined colo
 ```
 
 
-Also we can change the styles for all the presenters by default.
-We can put by default all the letters in bold.
+Also we can change the styles for all the presenters by default. For instance, we can put all the text in bold by default.
 
 ```
 '.application [
@@ -229,19 +220,20 @@ We can put by default all the letters in bold.
 !!todo unclear what is EnvironmentFont vs Font What are the environmental variables
 
 
-### Defining an Application
+### Defining an application
 
 
-To use styles we need to associate the main presenter with an application. The class `SpApplication` already has default styles. To not redefine all the properties for all the presenters, we can concatenate the default styles \(`SpStyle defaultStyleSheet`\) with our own. As said above, the styles are STON files that need to be parsed.
+To use styles we need to associate the main presenter with an application. The class `SpApplication` already has default styles. To not redefine all the properties for all the presenters, we can concatenate the default styles \(`SpStyle defaultStyleSheet`\) with our own.
 
-To parse the string into a STON we can use the class `SpStyleVariableSTONReader`.
+To parse a string into a STON we use the class `SpStyleVariableSTONReader`.
 
 ```
 presenter := SpPresenter new.
-presenter application: (app := SpApplication new).
+app := SpApplication new.
+presenter application: app.
 
-styleSheet := SpStyle defaultStyleSheet, 
-    (SpStyleVariableSTONReader fromString: 
+styleSheet := SpStyle defaultStyleSheet,
+    (SpStyleVariableSTONReader fromString:
     '.application [
          Font { #bold: true },
             .lightGreen [ Draw { #color: #B3E6B5 } ],
@@ -253,7 +245,7 @@ app styleSheet: styleSheet.
 ```
 
 
-Now, we can add one or more styles to a presenter, as follows and whose result is shown in Figure *@style5@*.
+Now we can add styles to a presenter, as follows and whose result is shown in Figure *@style5@*.
 
 ```
 presenter layout: (SpBoxLayout newTopToBottom
@@ -262,13 +254,13 @@ presenter layout: (SpBoxLayout newTopToBottom
 
 label label: 'I am a label'.
 label addStyle: 'lightGreen'.
-label addStyle: 'black'.
+label addStyle: 'bgBlack'.
 
-presenter openWithSpec.
+presenter open.
 ```
 
 
-![Styling.](figures/style5.png width=50&label=style5)
+![The stylesheet had been applied to the label.](figures/style5.png width=50&label=style5)
 
 ### Dynamically applying styles
 
@@ -286,8 +278,7 @@ label addStyle: 'blue'.
 
 ### Now using classes
 
-Up until now we just wrote scripts. Now we want to show how we can use style using presenter classes.
-To properly use styles, it is better to define a custom application as a subclass of `SpApplication`.
+Until now we just wrote scripts. Now we want to show how we can use styles using presenter classes. To properly use styles, it is better to define a custom application as a subclass of `SpApplication`.
 
 
 !!todo How do we associate an application to a presenter?
@@ -299,12 +290,12 @@ SpApplication << #CustomStylesApplication
 ```
 
 
-In the class, we need to override the method `styleSheet` to return our custom stylesheet concatenated with the default one.
+In the class, we override the method `styleSheet` to return our custom stylesheet concatenated with the default one.
 
 ```
 CustomStylesApplication >> styleSheet
 
-    ^ SpStyle defaultStyleSheet, 
+    ^ SpStyle defaultStyleSheet,
         (SpStyleVariableSTONReader fromString:
     '.application [
         Font { #bold: true },
@@ -318,7 +309,7 @@ CustomStylesApplication >> styleSheet
         .smallFontSize [ Font { #size: 14 } ],
         .icon [ Geometry { #width: 30 } ],
         .buttonStyle [ Geometry { #width: 110 } ],
-        .labelStyle [ 
+        .labelStyle [
             Geometry { #height: 25 },
             Font { #size: 12 }    ]
     ]')
@@ -331,7 +322,7 @@ We can use different properties in the same style. For example, in `labelStyle` 
 ### Defining a presenter for the editor
 
 
-For the main presenter, we will build a mini-text viewer in which we will be able to change the size and font of the text that we are viewing.
+For the main presenter, we will build a mini text viewer in which we will be able to change the size and font of the text that we are viewing.
 
 ```
 SpPresenter << #CustomStylesPresenter
@@ -380,13 +371,13 @@ CustomStylesPresenter >> instantiatePresenters
 
 ```
 CustomStylesPresenter >> initializeLayout
-    
+
     self layout: (SpBoxLayout newTopToBottom
         add: label expand: false;
         add: (SpBoxLayout newLeftToRight
             add: textFontButton expand: false;
             add: codeFontButton expand: false;
-            addLast: zoomOutButton expand: false;        
+            addLast: zoomOutButton expand: false;
             addLast: zoomInButton expand: false;
             yourself)
         expand: false;
@@ -406,14 +397,14 @@ CustomStylesPresenter>> initializeWindow: aWindowPresenter
 ```
 
 
-Without setting the custom styles nor using our custom application in the presenter, we obtain Figure *@style7@*:
+Without setting the custom styles nor using our custom application in the presenter, we obtain Figure *@style7@*, assuming that the "Pharo Dark" theme is in effect:
 
 ![Styling.](figures/style7.png width=70&label=style7)
 
 ### Initializing styles
 
 
-We do not want the black background color for the text presenter. We would like to have a sort of muti-line label. We want the zoom button to be smaller as they only have icons. We want to have the option to change the size and font of the text inside the text presenter. Finally, we want to change the color of the label, change its height and make it a little bit bigger.
+We do not want the black background color for the text presenter. We would like to have a sort of multi-line label. We want the zoom buttons to be smaller as they only have icons. We want to have the option to change the size and font of the text inside the text presenter. Finally, we want to change the color of the label, change its height and make it a little bit bigger.
 
 ```
 CustomStylesPresenter >> initializeStyles
@@ -426,32 +417,32 @@ CustomStylesPresenter >> initializeStyles
     the font size will be the small one."
     text addStyle: 'codeFont'.
     text addStyle: 'smallFontSize'.
-    
+
     "Change the background color."
     text addStyle: 'bgOpaque'.
 
     "But a smaller width for the zoom buttons"
     zoomInButton addStyle: 'icon'.
     zoomOutButton addStyle: 'icon'.
-    
+
     codeFontButton addStyle: 'buttonStyle'.
     textFontButton addStyle: 'buttonStyle'.
 
     "As this presenter is the container, set to self the container
     style to add a padding and border width."
-    
+
     self addStyle: 'container'
 ```
 
 
 ![Styled editor.](figures/style8.png width=70&label=style8)
 
-Finally, we have to override the `start` method in the application. With this, we are going to set the application of the presenter and run the presenter from the application.
+Finally, we have to override the `start` method in the application. We are going to set the application of the presenter and run the presenter from the application.
 
 ```
 CustomStylesApplication >> start
 
-    (self new: CustomStylesPresenter) openWithSpec
+    (self new: CustomStylesPresenter) open
 ```
 
 
@@ -463,11 +454,11 @@ Now, when we run `CustomStylesApplication new start` we will obtain Figure *@sty
 ### Wiring buttons
 
 
-The only thing missing is to add the behavior when pressing the buttons.
+The only thing missing is to add the behavior of the buttons.
 
-For example, if we click on the zoom-in button we want to remove the `smallFontStyle` and add the `bigFontSize`. When we click on the text font button, we should remove the style `codeFont` and add the `textFont` style. 
+For example, if we click on the zoom-in button we want to remove the `smallFontStyle` and add the `bigFontSize`. When we click on the text font button, we want to remove the style `codeFont` and add the `textFont` style. 
 
-This is what to do in the `connectPresenters` method defined below:
+This is what we have to do in the `connectPresenters` method:
 
 ```
 CustomStylesPresenter >> connectPresenters
@@ -475,32 +466,32 @@ CustomStylesPresenter >> connectPresenters
     zoomInButton action: [
         text removeStyle: 'smallFontSize'.
         text addStyle: 'bigFontSize' ].
-    zoomOutButton action: [ 
+    zoomOutButton action: [
         text removeStyle: 'bigFontSize'.
         text addStyle: 'smallFontSize'].
 
     codeFontButton action: [
         text removeStyle: 'textFont'.
         text addStyle: 'codeFont' ].
-    textFontButton action: [ 
+    textFontButton action: [
         text removeStyle: 'codeFont'.
         text addStyle: 'textFont']
 ```
 
 
-Now, when we click on zoom in, we obtain Figure *@style9@*.
+When we click on the the "zoom in" button, the size of the text changes as shown in Figure *@style9@*.
 
 ![Zoomed styled editor.](figures/style9.png width=60&label=style9)
 
-Now, when we select the button text font, we obtain Figure *@style10@*.
+When we click the "Text font" button, the font of the text changes as shown in Figure *@style10@*.
 
-![Zoomed styled editor.](figures/style10.png width=60&label=style10)
-
-
+![Styled editor with other font.](figures/style10.png width=60&label=style10)
 
 
 
-### Spec implementation details 
+
+
+### Spec implementation details
 
 You can ask an adapter for its style name using the message `styleName`
 
@@ -512,4 +503,4 @@ You can ask an adapter for its style name using the message `styleName`
 
 ### Conclusion
 
-Using styles in Spec is great. It makes it easier to have a consistent design as we can add the same style to several presenters. If we want to change some style, we only edit the styles sheet. Also, the styles automatically scale if we change the font size of all the images. They are one of the main reasons why in Spec we have the notion of an application. We can dynamically change how a presenter looks.
+Using styles in Spec is great. It makes it easier to have a consistent design as we can add the same style to several presenters. If we want to change some style, we only edit the stylesheet. Also, the styles automatically scale if we change the font size of all the images. These are the main reasons why in Spec we have the notion of an application. We can dynamically change how a presenter looks.


### PR DESCRIPTION
This is the first-pass review of chapter 14 "Styling Applications".

There are several issues with this chapter.
* It mentions themes, but it does not explain what themes are, how they are applied, and more importantly, how stylesheets relate to themes.
* I think it should be stated clearly that some aspects of the UI cannot be styled with stylesheets, e.g. the colour of a selected element in a list or a table, the text selection colour, the caret colour, and the colour of the placeholder in a text field (this is a non-exhaustive list).
* Are the two stylesheet examples in section 14.3 "STON notation" useful? I do not think so. It is good to give some idea about what is possible, but two pages of stylesheets is too much.
* Section 14.3 "STON notation" associates `stonName`s with `SpStyle` subclasses, but the classes are introduced in the next section ("Anatomy of a style"). I think that both sections have to be rewritten to avoid forward references and to make the text easier to understand. There are still some questions in the sections that indicate this. "Anatomy of a style" should do just that: what is the syntax of a style? I would not mix it with code. The anatomy of a style is part of the STON notation. How the `stonName`s are mapped on classes should move to a separate (new) section.
* As stated clearly in chapter 3 ("Most of Spec in one example"), "Defining a style class, however, works differently for each backend. While Gtk accepts (mostly) regular CSS to style your widgets, Morphic has its own sub-framework." I think this is a major issue because one of the core principles of Spec is reusability. That core principle breaks in the stylesheets. Chapter 14 does not give any examples of GTK stylesheets, which is a gap in the book. I am not advocating that it should be included, but stating that Morphic is the main focus is probably better than not saying anything about GTK.
* It would be good to mention where to find the default stylesheet (`SpStyle class>>#defaultStyleSheetData`), but as flagged in `SpStyle class>>#defaultStyleSheet`, the default stylesheet should reside in the Pharo application, not in `SpStyle class`.