### PR TITLE
Adapt contextmenu to actions

### DIFF
--- a/Chapters/CaseStudyOne/HowTo.pillar
+++ b/Chapters/CaseStudyOne/HowTo.pillar
@@ -67,13 +67,7 @@ initializePresenters
 !! Menu
 
 
-contextMenu: [ ]
-	si dynamic
-	
-
-self newMenu
-	addItem
-on group per default
+aPresenter actions: anActionGroup
 
 
 !! Style

--- a/Chapters/CaseStudyTwo/CaseStudyTwo.md
+++ b/Chapters/CaseStudyTwo/CaseStudyTwo.md
@@ -439,7 +439,7 @@ TodoListPresenter >> initializePresenters
                 title: 'Title'
                 evaluated: [ :task | task title ]);
         yourself.
-    todoListPresenter contextMenu: self todoListContextMenu.
+    todoListPresenter actions: self todoListActions.
 
     addButton := self newButton
         label: 'Add task';
@@ -449,25 +449,26 @@ TodoListPresenter >> initializePresenters
 
 What is added now? 
  
-- `contextMenu: self todoListContextMenu` sets the context menu to what is defined in the method `todoListContextMenu`. Let us study right now.
+- `actions: self todoListActions` sets the context menu to what is defined in the method `todoListActions`. Let us study right now.
 
 
 ```Smalltalk
-TodoListPresenter >> todoListContextMenu
+TodoListPresenter >> todoListActions
 
-    ^ self newMenu 
-        addItem: [ :item | item 
-                    name: 'Edit...'; 
-                    action: [ self editSelectedTask ] ];
-        addItem: [ :item | item 
-                    name: 'delete'; 
-                    action: [ self deleteSelectedTask ] ]
+    ^ SpGroupAction new
+        addItemWith: [ :item | item 
+            name: 'Edit...'; 
+            action: [ self editSelectedTask ] ];
+        addItemWith: [ :item | item 
+            name: 'delete'; 
+            action: [ self deleteSelectedTask ] ];
+        yourself
 ```
 
-This method creates a menu to be displayed when pressing right-click on the table. Let's see what it contains: 
+This method creates aa action group that will be used to the presenter as a context menu to be displayed when pressing right-click on the table. Let's see what it contains: 
 
-- `self newMenu` as all other _factory methods_, this creates a menu presenter to be attached to another presenter.
-- `addItem: [ :item | ... ]` add an item, with a `name:` and an associated `action:`
+- `SpGroupAction new` this creates an action group to contain the actions that will be attached to another presenter.
+- `addItemWith: [ :item | ... ]` add an item, with a `name:` and an associated `action:`
 
 And now let's define the actions
 

--- a/Chapters/Commander2/Commander.md
+++ b/Chapters/Commander2/Commander.md
@@ -205,7 +205,7 @@ ContactBookPresenter >> initializePresenters
     table
         addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);
         addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).
-    table contextMenu: [ self rootCommandsGroup beRoot asMenuPresenter ].
+    table actions: self rootCommandsGroup.
     table items: contactBook contacts.
 ```
 
@@ -281,7 +281,7 @@ ContactBookPresenter >> initializePresenters
     table
         addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);
         addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).
-    table contextMenu: [ (self rootCommandsGroup / 'Context Menu') beRoot asMenuPresenter ].
+    table actions: self rootCommandsGroup / 'Context Menu'.
     table items: contactBook contacts
 ```
 
@@ -527,7 +527,7 @@ ContactBookPresenter >> initializePresenters
     table
         addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);
         addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).
-    table contextMenu: [ (self rootCommandsGroup / 'Context Menu') beRoot asMenuPresenter ].
+    table actions: self rootCommandsGroup / 'Context Menu'.
     table items: contactBook contents.
     menuBar := (self rootCommandsGroup / 'MenuBar') asMenuBarPresenter.
 ```

--- a/Chapters/ListTreeTable/ListTreeTable.md
+++ b/Chapters/ListTreeTable/ListTreeTable.md
@@ -239,7 +239,7 @@ The message `expandPath:` shows that we can expand a specific item by a path.
 
 ![A tree with a menu. %width=45&anchor=figTreemenu](figures/TreeWithMenu.png)
 
-The following script shows how to use a context menu, you can add, remove and replace menus, but it's dynamic nature is also present in the api, by seinding blocks to messages like `name:`, `actionEnabled:` and `actionVisible:`.
+The following script shows how to use a context menu, you can add, remove and replace menus, but it's dynamic nature is also present in the api, by seinding blocks to messages like `dynamicName:`, `actionEnabled:` and `actionVisible:`.
 
 ```
 | tree |
@@ -248,9 +248,9 @@ tree roots: { Object };
 	children: [ :aClass | aClass subclasses ];
 	displayIcon: [ :aClass | self iconNamed: aClass systemIconName ];
 	display: [ :aClass | aClass name ];
-	actionsWith: [ :aGroup | 
-		aGroup addActionWith: [ :action | 
-			action name: [ tree selectedItem asString ] ] ];
+	actionsWith: [ :group | group 
+		addActionWith: [ :action | action 
+			dynamicName: [ tree selectedItem asString ] ] ];
 	open
 ```
 

--- a/Chapters/ListTreeTable/ListTreeTable.md
+++ b/Chapters/ListTreeTable/ListTreeTable.md
@@ -239,9 +239,7 @@ The message `expandPath:` shows that we can expand a specific item by a path.
 
 ![A tree with a menu. %width=45&anchor=figTreemenu](figures/TreeWithMenu.png)
 
-The following script shows how to use a dynamic context menu. This is a dynamic menu because its content is recalculated.
-The dynamic aspect is expressed by a block. Figure *@figTreemenu@* shows the result.
-
+The following script shows how to use a context menu, you can add, remove and replace menus, but it's dynamic nature is also present in the api, by seinding blocks to messages like `name:`, `actionEnabled:` and `actionVisible:`.
 
 ```
 | tree |
@@ -250,10 +248,9 @@ tree roots: { Object };
 	children: [ :aClass | aClass subclasses ];
 	displayIcon: [ :aClass | self iconNamed: aClass systemIconName ];
 	display: [ :aClass | aClass name ];
-	contextMenu: [
-		SpMenuPresenter new
-			addGroup: [ :group |
-				group addItem: [ :item | item name: tree selectedItem asString ] ] ];
+	actionsWith: [ :aGroup | 
+		aGroup addActionWith: [ :action | 
+			action name: [ tree selectedItem asString ] ] ];
 	open
 ```
 

--- a/Chapters/ToPlaceSomewhere.pillar
+++ b/Chapters/ToPlaceSomewhere.pillar
@@ -64,19 +64,19 @@ how do you have a CmUICommandGroup ? That's abstract... you should have a CmComm
 in anycase, if this is the first case, then you do:
 
 
-myGroup asSpecGroup asMenuPresenter
+myGroup asSpecGroup
 
 and if is the second (most likely)
 you just do
 
-myGroup asMenuPresenter
+myGroup
 
 Esteban Lorenzano — 12/06/2022 9:36 PM
 also, status of presenters are not updated all the time
 to get that, you need to pass the context menu as a block, not as a direct instance, e.g. :
 
 myPresenter
-  contextMenu; [ myGroup asMenuPresenter ];
+  actions: myGroup;
   yourself
 
 Yes, I have a SpecCommandGroup but I just got lost in this class hierarchy


### PR DESCRIPTION
this PR adapts the examples and explanations to the new action architecture, that will be used to add context menus and keybindings to presenters.